### PR TITLE
chore(heal): auto-fix 2026-04-23

### DIFF
--- a/docs/heal/2026-04-23-heal.md
+++ b/docs/heal/2026-04-23-heal.md
@@ -1,0 +1,123 @@
+# CeSoir Daily Heal Report — 2026-04-23
+
+Run time: 2026-04-23 ~03:00 Paris time (automated, unattended)
+
+---
+
+## Health Probe
+
+| Route | Status | Response Time |
+|---|---|---|
+| `/` | 200 | 1822ms |
+| `/login` | 200 | 641ms |
+| `/events` | 307 | 636ms |
+| `/manifesto` | 307 | 155ms |
+| `/help` | 307 | 296ms |
+| `/why-free` | 200 | 551ms |
+| `/api/health` | 200 | 2380ms |
+
+- **`/api/health` payload:** `{ status: "ok", checks: { app: "ok", db: "ok" }, version: "e8f05b4", env: "production" }` — DB healthy, no alert.
+- **`/` response time:** 1822ms — within 3s threshold.
+- **`<title>` tag:** present (`CeSoir — Trouve quelqu'un pour ce soir`).
+- All routes 2xx/3xx. No 5xx detected.
+
+---
+
+## Drift vs Previous Baseline
+
+**No previous baseline exists.** This is the first heal run. Today's report becomes the baseline.
+
+---
+
+## Fixes Applied
+
+### Pattern B — Missing Suspense boundary around `useSearchParams` (4 files)
+
+Next.js 16 requires `useSearchParams()` callers to be wrapped in `<Suspense>` for static prerender.
+
+- **`src/app/(app)/browse/page.tsx`** — Added `Suspense` import; renamed `BrowsePage` → `BrowsePageInner`; new `BrowsePage` export wraps `<Suspense fallback={null}><BrowsePageInner /></Suspense>`.
+- **`src/app/(app)/plans/page.tsx`** — Same pattern: `PlansPage` → `PlansPageInner`.
+- **`src/app/(app)/plans/create/page.tsx`** — Same pattern: `CreatePlanPage` → `CreatePlanPageInner`.
+- **`src/app/(app)/feed/page.tsx`** — Same pattern: `FeedPage` → `FeedPageInner`.
+
+Reference: `src/app/(auth)/register/page.tsx` (Wave 15.1 fix already applied).
+
+### Pattern A — Hydration mismatch from `useReducedMotion` (3 files)
+
+`useReducedMotion()` returns `null` on SSR and `true|false` on CSR; without the mounted gate, these components render different DOM shapes on server vs client.
+
+- **`src/components/ambient/BreatheAvatar.tsx`** — Added `useState/useEffect` imports + mounted gate. `if (!mounted || reduced)` guards the `m.div` path.
+- **`src/components/ambient/FloatEmoji.tsx`** — Same: guards `m.span` path.
+- **`src/components/ambient/GradientShift.tsx`** — Same: guards `m.div/m.span` path.
+
+Reference: `src/components/motion/PageTransition.tsx` (commit e8f05b4).
+
+### Pattern G — `console.log` in `src/lib/` (2 files)
+
+- **`src/lib/registerSW.ts`** — Replaced 2× `console.log` calls with `logger.info("sw_registered", {...})` and `logger.info("sw_update_available")`. Logger already imported.
+- **`src/lib/offline-queue.ts`** — Added `import { logger } from "@/lib/logger"`; replaced `console.log` with `logger.info("offline_queue_synced", { type, payload })`.
+
+---
+
+## TypeScript Validation
+
+`npx tsc --noEmit` run after all fixes. No new errors introduced in modified files.
+Pre-existing errors in `tests/e2e/`, `vitest.config.ts`, `playwright.config.ts`, `instrumentation*.ts`, `next.config.ts`, and two admin pages (`about/page.tsx`, `admin/finance/page.tsx`) are unchanged baseline noise from missing devDependency type packages.
+
+## Lint Validation
+
+`npm run lint` fails with `Cannot find package 'eslint-plugin-storybook'` — **pre-existing infrastructure issue**, unrelated to today's changes.
+
+---
+
+## Fixes Suggested But Not Applied (Requires Human Review)
+
+### Pattern F — Hex color leakage in TSX files (flag only)
+
+Top offenders (first baseline — all are "new" since no prior baseline exists):
+
+| File | Hex count |
+|---|---|
+| `src/components/landing/PhoneVideo.tsx` | 28 |
+| `src/components/landing/MoonHero.tsx` | 22 |
+| `src/components/landing/SceneController.tsx` | 11 |
+
+Design team to migrate to tokens. Do not auto-fix.
+
+### Pattern A — Additional components without mounted gate
+
+The following also call `useReducedMotion` with conditional DOM-shape rendering but were not auto-fixed because their `active`-prop gating or internal-only animation toggling reduces SSR exposure. Review recommended:
+
+- `src/components/moments/StreakUnlock.tsx` — guarded by `active` prop
+- `src/components/moments/LevelUpCounter.tsx` — uses reducedMotion inside a `useEffect`
+- `src/components/moments/SuperLikeHalo.tsx` — guarded by `active` prop, returns `null`
+- `src/components/moments/VerifyConfetti.tsx` — guarded by `!active || reduced`, returns `null`
+
+### Lint infrastructure
+
+`eslint-plugin-storybook` is missing from `node_modules`. Running `npm install` in CI or adding the package to devDependencies should resolve.
+
+---
+
+## CSP / remotePatterns Audit (Pattern C + D)
+
+All `next.config.ts` `remotePatterns` hostnames are present in CSP `img-src`. No drift detected:
+
+| Hostname | remotePatterns | img-src |
+|---|---|---|
+| `images.unsplash.com` | ✓ | ✓ |
+| `ui-avatars.com` | ✓ | ✓ |
+| `api.dicebear.com` | ✓ | ✓ |
+| `ycyxmvzilzkusecpgvbi.supabase.co` | ✓ | ✓ (via `*.supabase.co`) |
+| `randomuser.me` | ✓ | ✓ |
+| `i.pravatar.cc` | ✓ | ✓ |
+
+---
+
+## Next Run
+
+2026-04-24 ~03:00 Paris time (automated).
+
+---
+
+*Generated by CeSoir self-healing patrol agent.*

--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, Suspense } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
@@ -50,6 +50,14 @@ function candidateToProfile(c: MatchCandidate): Profile {
 }
 
 export default function BrowsePage() {
+  return (
+    <Suspense fallback={null}>
+      <BrowsePageInner />
+    </Suspense>
+  );
+}
+
+function BrowsePageInner() {
   const { user } = useAuth();
   const { latitude, longitude } = useGeolocation();
   const searchParams = useSearchParams();

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { m, AnimatePresence } from "motion/react";
@@ -104,6 +104,14 @@ const containerVariants = feedVariants.container;
 const itemVariants = feedVariants.card;
 
 export default function FeedPage() {
+  return (
+    <Suspense fallback={null}>
+      <FeedPageInner />
+    </Suspense>
+  );
+}
+
+function FeedPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { reducedMotion } = useAccessibility();

--- a/src/app/(app)/plans/create/page.tsx
+++ b/src/app/(app)/plans/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { m } from "motion/react";
 import { springs } from "@/lib/motion-design";
@@ -10,6 +10,14 @@ import PageHeader from "@/components/ui/PageHeader";
 const PUBLIC_TYPES: PlanType[] = ["flash", "soiree", "popup"];
 
 export default function CreatePlanPage() {
+  return (
+    <Suspense fallback={null}>
+      <CreatePlanPageInner />
+    </Suspense>
+  );
+}
+
+function CreatePlanPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const defaultType = (searchParams?.get("type") as PlanType) ?? "flash";

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { m, AnimatePresence, type Variants } from "motion/react";
@@ -36,6 +36,14 @@ function formatTime(iso: string): string {
 }
 
 export default function PlansPage() {
+  return (
+    <Suspense fallback={null}>
+      <PlansPageInner />
+    </Suspense>
+  );
+}
+
+function PlansPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const typeParam = searchParams?.get("type") as PlanType | null;

--- a/src/components/ambient/BreatheAvatar.tsx
+++ b/src/components/ambient/BreatheAvatar.tsx
@@ -14,6 +14,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 import { ambient } from "@/lib/motion-design";
 
 export interface BreatheAvatarProps {
@@ -30,7 +31,9 @@ export function BreatheAvatar({
   className,
 }: BreatheAvatarProps) {
   const reduced = useReducedMotion();
-  if (reduced) return <div className={className}>{children}</div>;
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  if (!mounted || reduced) return <div className={className}>{children}</div>;
   return (
     <m.div className={className} animate={ambient.breathe(duration)}>
       {children}

--- a/src/components/ambient/FloatEmoji.tsx
+++ b/src/components/ambient/FloatEmoji.tsx
@@ -11,6 +11,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 
 export interface FloatEmojiProps {
   /** The emoji character (or any inline text). */
@@ -30,7 +31,9 @@ export function FloatEmoji({
   ariaHidden = true,
 }: FloatEmojiProps) {
   const reduced = useReducedMotion();
-  if (reduced) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  if (!mounted || reduced) {
     return (
       <span className={className} aria-hidden={ariaHidden}>
         {children}

--- a/src/components/ambient/GradientShift.tsx
+++ b/src/components/ambient/GradientShift.tsx
@@ -15,6 +15,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 import { ambient } from "@/lib/motion-design";
 
 export interface GradientShiftProps {
@@ -34,8 +35,10 @@ export function GradientShift({
   as = "div",
 }: GradientShiftProps) {
   const reduced = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
   const Tag = as === "span" ? m.span : m.div;
-  if (reduced) {
+  if (!mounted || reduced) {
     if (as === "span") return <span className={className}>{children}</span>;
     return <div className={className}>{children}</div>;
   }

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { logger } from "@/lib/logger";
 
 /** Action queued while offline */
 export interface QueuedAction {
@@ -37,7 +38,7 @@ function saveQueue(queue: QueuedAction[]): void {
 
 async function processAction(action: QueuedAction): Promise<boolean> {
   await new Promise((resolve) => setTimeout(resolve, 200));
-  console.log(`[OfflineQueue] Synced action: ${action.type}`, action.payload);
+  logger.info("offline_queue_synced", { type: action.type, payload: action.payload });
   return true;
 }
 

--- a/src/lib/registerSW.ts
+++ b/src/lib/registerSW.ts
@@ -60,7 +60,7 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
       { scope: "/" }
     );
 
-    console.log("[SW] Enregistre avec succes :", registration.scope, "version", BUILD_VERSION);
+    logger.info("sw_registered", { scope: registration.scope, version: BUILD_VERSION });
 
     // Tell the worker which version to namespace its cache under.
     announceVersion(registration);
@@ -82,7 +82,7 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
 
           if (navigator.serviceWorker.controller) {
             // New version available — auto-activate
-            console.log("[SW] Nouvelle version disponible.");
+            logger.info("sw_update_available");
             newWorker.postMessage({ type: "SKIP_WAITING" });
           }
         }


### PR DESCRIPTION
## Summary

Daily self-healing patrol run — 2026-04-23 03:00 Paris time.

All routes healthy (no 5xx). First baseline established. 9 files patched across 3 patterns.

- **Pattern B (×4):** Added `<Suspense fallback={null}>` wrappers around `useSearchParams()` callers in `browse`, `plans`, `plans/create`, and `feed` pages — required by Next.js 16 for static prerender.
- **Pattern A (×3):** Added mounted-gate (`useState/useEffect`) to `BreatheAvatar`, `FloatEmoji`, and `GradientShift` to prevent SSR/CSR hydration mismatch from `useReducedMotion()` returning `null` on server vs `true|false` on client.
- **Pattern G (×2):** Replaced `console.log` calls in `src/lib/registerSW.ts` and `src/lib/offline-queue.ts` with `logger.info` from `@/lib/logger`.

## Test plan

- [ ] Verify `/browse`, `/plans`, `/plans/create`, `/feed` pages load without hydration errors in browser console
- [ ] Verify reduced-motion users see static fallback for BreatheAvatar / FloatEmoji / GradientShift without hydration warnings
- [ ] Confirm Vercel build passes (no new tsc errors in src/)
- [ ] Check `src/lib/offline-queue.ts` still syncs queued actions correctly after console → logger swap

## Flagged for human review (not auto-fixed)

- Pattern F: Hex color leakage in `landing/PhoneVideo.tsx` (28), `landing/MoonHero.tsx` (22), `landing/SceneController.tsx` (11) — design team token migration
- Pattern A: `StreakUnlock`, `LevelUpCounter`, `SuperLikeHalo`, `VerifyConfetti` use `useReducedMotion` with conditional rendering but are gated by `active` props — lower risk, manual review recommended
- Lint: `eslint-plugin-storybook` missing from node_modules — pre-existing, unrelated

See `docs/heal/2026-04-23-heal.md` for full report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ26UKSAJtz9TU4f3jxPmN)_