### PR TITLE
chore(heal): auto-fix 2026-04-24

### DIFF
--- a/docs/heal/2026-04-24-heal.md
+++ b/docs/heal/2026-04-24-heal.md
@@ -1,0 +1,109 @@
+# CeSoir Daily Heal Report — 2026-04-24
+
+Run at: 2026-04-24 03:00 Paris time (automated patrol)
+
+---
+
+## Phase 1 — Health Probe
+
+| Route | Status | Response Time |
+|-------|--------|---------------|
+| `/` | 200 | 1597ms |
+| `/login` | 200 | 183ms |
+| `/events` | 307 | 152ms |
+| `/manifesto` | 307 | 496ms |
+| `/help` | 307 | 177ms |
+| `/why-free` | 200 | 151ms |
+| `/api/health` | 200 | 2663ms |
+
+**`/api/health` body:**
+```json
+{"status":"ok","checks":{"app":"ok","db":"ok"},"version":"e8f05b4","env":"production"}
+```
+
+- DB: **ok** (no 503)
+- Title tag: present (`CeSoir — Trouve quelqu'un pour ce soir`)
+- `/` response time 1597ms — under 3s threshold ✓
+- No 5xx on any route ✓
+
+---
+
+## Phase 2 — Drift Detection
+
+**No prior baseline exists.** This is the first heal run. Today's report serves as the initial baseline.
+
+Status: **FIRST BASELINE ESTABLISHED**
+
+---
+
+## Phase 3 — Fixes Applied
+
+### Pattern A — Hydration mismatch from useReducedMotion (3 fixes)
+
+All three components conditionally rendered a different root element type (`<div>` vs `<m.div>`, or `<span>` vs `<m.span>`) based on `useReducedMotion()` without a mounted gate, causing hydration mismatches since SSR returns `null` for `useReducedMotion()`.
+
+- **`src/components/ambient/BreatheAvatar.tsx`** — Added `useState(false)` + `useEffect` mounted gate. Pre-hydration and reduced-motion paths now both return `<div>`, matching SSR.
+- **`src/components/ambient/FloatEmoji.tsx`** — Same pattern. Pre-mount path returns `<span>`.
+- **`src/components/ambient/GradientShift.tsx`** — Same pattern. Pre-mount path returns `<div>` or `<span>` matching the `as` prop.
+
+### Pattern B — Missing Suspense boundary around useSearchParams (4 fixes)
+
+Next.js 16 requires `useSearchParams()` callers to be wrapped in `<Suspense>` to allow static prerendering. The reference fix (`register/page.tsx`) was already applied; these four pages were missed.
+
+- **`src/app/(app)/plans/page.tsx`** — Extracted `PlansPageInner`, wrapped in `<Suspense fallback={null}>`.
+- **`src/app/(app)/plans/create/page.tsx`** — Extracted `CreatePlanPageInner`, wrapped in `<Suspense fallback={null}>`.
+- **`src/app/(app)/feed/page.tsx`** — Extracted `FeedPageInner`, wrapped in `<Suspense fallback={null}>`.
+- **`src/app/(app)/browse/page.tsx`** — Extracted `BrowsePageInner`, wrapped in `<Suspense fallback={null}>`.
+
+### Pattern G — console.log in src/lib/ (3 fixes)
+
+Replaced with `logger.info` from `@/lib/logger` (same API).
+
+- **`src/lib/registerSW.ts` line 63** — `console.log("[SW] Enregistre...")` → `logger.info`
+- **`src/lib/registerSW.ts` line 85** — `console.log("[SW] Nouvelle version...")` → `logger.info`
+- **`src/lib/offline-queue.ts` line 40** — `console.log("[OfflineQueue]...")` → `logger.info` (added logger import)
+
+---
+
+## Fixes Suggested but Not Applied (Requires Human Review)
+
+### Pattern F — Hex color leakage in TSX (top 3 offenders)
+
+These files have hardcoded hex values that should migrate to design tokens. **Not auto-fixed** — tokens migration is design team work.
+
+1. `src/components/landing/PhoneVideo.tsx` — 28 hex occurrences
+2. `src/components/landing/MoonHero.tsx` — 22 hex occurrences
+3. `src/components/landing/SceneController.tsx` — 11 hex occurrences
+
+### Pattern A — StreakUnlock.tsx (borderline)
+
+`src/components/moments/StreakUnlock.tsx` switches inner child element types (`<span>` vs `<m.span>`) based on `useReducedMotion()` when `active=true`. Outer wrapper is always `<div>` so no root element mismatch. Since this is a moment component activated only by user interaction (unlikely SSR'd in active state), risk is low. **Flagged for human review.**
+
+### ESLint infrastructure
+
+`eslint-plugin-storybook` package is not installed — `npm run lint` fails on `eslint.config.mjs` import. Pre-existing issue, not introduced by heal run. Requires `npm install` or devDependency fix.
+
+### TypeScript devDeps
+
+`@testing-library/user-event`, `playwright`, `vitest`, `@vitejs/plugin-react` types missing from `node_modules`. Pre-existing test infra issue.
+
+---
+
+## Patterns Checked (No Issues)
+
+- **Pattern C** — No next/image components reference external `https://` URLs outside `remotePatterns`. ✓
+- **Pattern D** — All `remotePatterns` hostnames covered in CSP `img-src`: unsplash, ui-avatars, api.dicebear.com, *.supabase.co, randomuser.me, i.pravatar.cc. ✓
+- **Pattern E** — All `PageTransition` imports route through `@/components/ui/PageTransition` (re-export shim) or `@/components/motion/PageTransition` (canonical). ✓
+- **`src/lib/logger.ts`** — `console.error`/`console.warn` in logger.ts are the logger implementation itself (with `// eslint-disable-next-line no-console`). Not replaced. ✓
+
+---
+
+## Critical Alerts
+
+None. All routes healthy, DB ok, no 5xx.
+
+---
+
+## Next Run
+
+2026-04-25 at 03:00 Paris time.

--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, Suspense } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
@@ -49,7 +49,7 @@ function candidateToProfile(c: MatchCandidate): Profile {
   };
 }
 
-export default function BrowsePage() {
+function BrowsePageInner() {
   const { user } = useAuth();
   const { latitude, longitude } = useGeolocation();
   const searchParams = useSearchParams();
@@ -547,6 +547,14 @@ function EmptyState({ onReset }: { onReset: () => void }) {
         Recommencer
       </button>
     </div>
+  );
+}
+
+export default function BrowsePage() {
+  return (
+    <Suspense fallback={null}>
+      <BrowsePageInner />
+    </Suspense>
   );
 }
 

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { m, AnimatePresence } from "motion/react";
@@ -103,7 +103,7 @@ function FeedSkeleton() {
 const containerVariants = feedVariants.container;
 const itemVariants = feedVariants.card;
 
-export default function FeedPage() {
+function FeedPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { reducedMotion } = useAccessibility();
@@ -400,5 +400,13 @@ export default function FeedPage() {
 
       <PullToRefresh onRefresh={handleRefresh}>{content}</PullToRefresh>
     </div>
+  );
+}
+
+export default function FeedPage() {
+  return (
+    <Suspense fallback={null}>
+      <FeedPageInner />
+    </Suspense>
   );
 }

--- a/src/app/(app)/plans/create/page.tsx
+++ b/src/app/(app)/plans/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { m } from "motion/react";
 import { springs } from "@/lib/motion-design";
@@ -9,7 +9,7 @@ import PageHeader from "@/components/ui/PageHeader";
 
 const PUBLIC_TYPES: PlanType[] = ["flash", "soiree", "popup"];
 
-export default function CreatePlanPage() {
+function CreatePlanPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const defaultType = (searchParams?.get("type") as PlanType) ?? "flash";
@@ -187,5 +187,13 @@ export default function CreatePlanPage() {
         </m.button>
       </main>
     </div>
+  );
+}
+
+export default function CreatePlanPage() {
+  return (
+    <Suspense fallback={null}>
+      <CreatePlanPageInner />
+    </Suspense>
   );
 }

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { m, AnimatePresence, type Variants } from "motion/react";
@@ -35,7 +35,7 @@ function formatTime(iso: string): string {
   return d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }).replace(":", "h");
 }
 
-export default function PlansPage() {
+function PlansPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const typeParam = searchParams?.get("type") as PlanType | null;
@@ -208,5 +208,13 @@ export default function PlansPage() {
         </m.div>
       )}
     </div>
+  );
+}
+
+export default function PlansPage() {
+  return (
+    <Suspense fallback={null}>
+      <PlansPageInner />
+    </Suspense>
   );
 }

--- a/src/components/ambient/BreatheAvatar.tsx
+++ b/src/components/ambient/BreatheAvatar.tsx
@@ -14,6 +14,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 import { ambient } from "@/lib/motion-design";
 
 export interface BreatheAvatarProps {
@@ -30,7 +31,10 @@ export function BreatheAvatar({
   className,
 }: BreatheAvatarProps) {
   const reduced = useReducedMotion();
-  if (reduced) return <div className={className}>{children}</div>;
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  if (!mounted || reduced) return <div className={className}>{children}</div>;
   return (
     <m.div className={className} animate={ambient.breathe(duration)}>
       {children}

--- a/src/components/ambient/FloatEmoji.tsx
+++ b/src/components/ambient/FloatEmoji.tsx
@@ -11,6 +11,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 
 export interface FloatEmojiProps {
   /** The emoji character (or any inline text). */
@@ -30,7 +31,10 @@ export function FloatEmoji({
   ariaHidden = true,
 }: FloatEmojiProps) {
   const reduced = useReducedMotion();
-  if (reduced) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  if (!mounted || reduced) {
     return (
       <span className={className} aria-hidden={ariaHidden}>
         {children}

--- a/src/components/ambient/GradientShift.tsx
+++ b/src/components/ambient/GradientShift.tsx
@@ -15,6 +15,7 @@
  */
 
 import { m, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 import { ambient } from "@/lib/motion-design";
 
 export interface GradientShiftProps {
@@ -34,8 +35,11 @@ export function GradientShift({
   as = "div",
 }: GradientShiftProps) {
   const reduced = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
   const Tag = as === "span" ? m.span : m.div;
-  if (reduced) {
+  if (!mounted || reduced) {
     if (as === "span") return <span className={className}>{children}</span>;
     return <div className={className}>{children}</div>;
   }

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { logger } from "@/lib/logger";
 
 /** Action queued while offline */
 export interface QueuedAction {
@@ -37,7 +38,7 @@ function saveQueue(queue: QueuedAction[]): void {
 
 async function processAction(action: QueuedAction): Promise<boolean> {
   await new Promise((resolve) => setTimeout(resolve, 200));
-  console.log(`[OfflineQueue] Synced action: ${action.type}`, action.payload);
+  logger.info("[OfflineQueue] Synced action", { type: action.type, payload: action.payload });
   return true;
 }
 

--- a/src/lib/registerSW.ts
+++ b/src/lib/registerSW.ts
@@ -60,7 +60,7 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
       { scope: "/" }
     );
 
-    console.log("[SW] Enregistre avec succes :", registration.scope, "version", BUILD_VERSION);
+    logger.info("[SW] Enregistre avec succes", { scope: registration.scope, version: BUILD_VERSION });
 
     // Tell the worker which version to namespace its cache under.
     announceVersion(registration);
@@ -82,7 +82,7 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
 
           if (navigator.serviceWorker.controller) {
             // New version available — auto-activate
-            console.log("[SW] Nouvelle version disponible.");
+            logger.info("[SW] Nouvelle version disponible.");
             newWorker.postMessage({ type: "SKIP_WAITING" });
           }
         }


### PR DESCRIPTION
## Daily heal run — 2026-04-24

Automated self-healing patrol. Full report: `docs/heal/2026-04-24-heal.md`

### Health probe
All routes healthy (no 5xx). `/api/health` → `{status:ok, db:ok}`. `/` at 1597ms.

### Fixes applied (10 files, 3 patterns)

**Pattern A — Hydration mismatch (useReducedMotion without mounted gate)**
- `src/components/ambient/BreatheAvatar.tsx`
- `src/components/ambient/FloatEmoji.tsx`
- `src/components/ambient/GradientShift.tsx`

All three switched root element type (`<div>` vs `<m.div>`, `<span>` vs `<m.span>`) based solely on `useReducedMotion()`. Since SSR returns `null` for that hook, the server always rendered the animated path while reduced-motion users got a mismatch on hydration. Added `useState(false)` + `useEffect` mounted gate (same pattern as `PageTransition.tsx`).

**Pattern B — Missing Suspense around useSearchParams (Next.js 16)**
- `src/app/(app)/plans/page.tsx`
- `src/app/(app)/plans/create/page.tsx`
- `src/app/(app)/feed/page.tsx`
- `src/app/(app)/browse/page.tsx`

Extracted each page body into an `*Inner` component; default export wraps in `<Suspense fallback={null}>`. Matches the existing fix in `register/page.tsx`.

**Pattern G — console.log in src/lib/**
- `src/lib/registerSW.ts` (2 calls) → `logger.info`
- `src/lib/offline-queue.ts` (1 call) → `logger.info` + added logger import

### Flagged for human review (not auto-fixed)
- **Pattern F** — Hex leakage: PhoneVideo.tsx (28), MoonHero.tsx (22), SceneController.tsx (11). Design-token migration needed.
- **Pattern A borderline** — `StreakUnlock.tsx` switches inner child types when `active=true`; low risk since it's a moment component.
- **Infra** — `eslint-plugin-storybook` missing from node_modules; `npm run lint` fails. Pre-existing.

### Critical alerts
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxLuV1z9Qh8Sseg44JbMUD)_