### PR TITLE
fix(next): wrap 4 useSearchParams pages in Suspense boundary

### DIFF
--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, Suspense } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
@@ -49,7 +49,7 @@ function candidateToProfile(c: MatchCandidate): Profile {
   };
 }
 
-export default function BrowsePage() {
+function BrowsePageInner() {
   const { user } = useAuth();
   // 2026-04-24 (CPO-002): we now pull `error` + `loading` from the geo hook
   // so we can show a specific "enable location" state instead of silently
@@ -592,3 +592,13 @@ function EmptyState({ onReset }: { onReset: () => void }) {
 
 // Wave 15 · CPO — MatchToast replaced by full-screen MatchCinematic.
 // See src/components/app/MatchCinematic.tsx.
+
+// 2026-04-24: Wrap in Suspense for useSearchParams bail-out (Next 16 requirement).
+// Same pattern as feed/plans/plans-create after /glowup/suspense-boundaries PR.
+export default function BrowsePage() {
+  return (
+    <Suspense fallback={null}>
+      <BrowsePageInner />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { m, AnimatePresence } from "motion/react";
@@ -103,7 +103,7 @@ function FeedSkeleton() {
 const containerVariants = feedVariants.container;
 const itemVariants = feedVariants.card;
 
-export default function FeedPage() {
+function FeedPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { reducedMotion } = useAccessibility();
@@ -400,5 +400,13 @@ export default function FeedPage() {
 
       <PullToRefresh onRefresh={handleRefresh}>{content}</PullToRefresh>
     </div>
+  );
+}
+
+export default function FeedPage() {
+  return (
+    <Suspense fallback={null}>
+      <FeedPageInner />
+    </Suspense>
   );
 }

--- a/src/app/(app)/plans/create/page.tsx
+++ b/src/app/(app)/plans/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { m } from "motion/react";
 import { springs } from "@/lib/motion-design";
@@ -9,7 +9,7 @@ import PageHeader from "@/components/ui/PageHeader";
 
 const PUBLIC_TYPES: PlanType[] = ["flash", "soiree", "popup"];
 
-export default function CreatePlanPage() {
+function CreatePlanPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const defaultType = (searchParams?.get("type") as PlanType) ?? "flash";
@@ -187,5 +187,13 @@ export default function CreatePlanPage() {
         </m.button>
       </main>
     </div>
+  );
+}
+
+export default function CreatePlanPage() {
+  return (
+    <Suspense fallback={null}>
+      <CreatePlanPageInner />
+    </Suspense>
   );
 }

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { m, AnimatePresence, type Variants } from "motion/react";
@@ -35,7 +35,7 @@ function formatTime(iso: string): string {
   return d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }).replace(":", "h");
 }
 
-export default function PlansPage() {
+function PlansPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const typeParam = searchParams?.get("type") as PlanType | null;
@@ -208,5 +208,13 @@ export default function PlansPage() {
         </m.div>
       )}
     </div>
+  );
+}
+
+export default function PlansPage() {
+  return (
+    <Suspense fallback={null}>
+      <PlansPageInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Context

Next.js 16 requires any page that calls `useSearchParams()` to be wrapped in a `<Suspense>` boundary — otherwise it triggers prerender bailout at build time and a rendering freeze on client-side navigation.

Four CeSoir pages were missing this wrap. Detected by the 2026-04-24 overnight `/saas-heal` patrol run (branch `heal/2026-04-24-auto`).

## Changes

| File | Lines |
|---|---|
| `src/app/(app)/feed/page.tsx` | +10 / -2 |
| `src/app/(app)/plans/page.tsx` | +10 / -2 |
| `src/app/(app)/plans/create/page.tsx` | +10 / -2 |
| `src/app/(app)/browse/page.tsx` | +12 / -2 |

Total: **4 files, +42 / -8**.

## Origin of each fix

- **feed / plans / plans-create**: cherry-picked verbatim from `heal/2026-04-24-auto` (pure mechanical wrap, zero conflict with master).
- **browse**: redone manually on top of master because the heal version had reverted the CPO-002 geolocation-refused state that shipped in #4.

## Validation

```
npx tsc --noEmit    → 0 errors
```

Tests + build not re-run locally (commit is a mechanical refactor, identical pattern to `register/page.tsx` from Wave 15.1).

## Follow-up

The heal branch `heal/2026-04-24-auto` is now obsolete after this merge and should be deleted. I'll do that once this PR lands.