### PR TITLE
Patrol Wave 2 — #7 + #8 + #10 + #11 + close #12/#14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/supercluster": "^7.1.3",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
-        "face-api.js": "^0.22.2",
+        "@vladmandic/face-api": "^1.7.15",
         "lucide-react": "^1.8.0",
         "maplibre-gl": "^5.23.0",
         "motion": "^12.38.0",
@@ -5560,18 +5560,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/webgl-ext": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz",
-      "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==",
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6482,6 +6470,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vladmandic/face-api": {
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@vladmandic/face-api/-/face-api-1.7.15.tgz",
+      "integrity": "sha512-WDMmK3CfNLo8jylWqMoQgf4nIst3M0fzx1dnac96wv/dvMTN4DxC/Pq1DGtduDk1lktCamQ3MIDXFnvrdHTXDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -8617,60 +8614,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/face-api.js": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/face-api.js/-/face-api.js-0.22.2.tgz",
-      "integrity": "sha512-9Bbv/yaBRTKCXjiDqzryeKhYxmgSjJ7ukvOvEBy6krA0Ah/vNBlsf7iBNfJljWiPA8Tys1/MnB3lyP2Hfmsuyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tensorflow/tfjs-core": "1.7.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/face-api.js/node_modules/@tensorflow/tfjs-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.7.0.tgz",
-      "integrity": "sha512-uwQdiklNjqBnHPeseOdG0sGxrI3+d6lybaKu2+ou3ajVeKdPEwpWbgqA6iHjq1iylnOGkgkbbnQ6r2lwkiIIHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/offscreencanvas": "~2019.3.0",
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "node-fetch": "~2.1.2",
-        "seedrandom": "2.4.3"
-      },
-      "engines": {
-        "yarn": ">= 1.3.2"
-      }
-    },
-    "node_modules/face-api.js/node_modules/@types/seedrandom": {
-      "version": "2.4.27",
-      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.27.tgz",
-      "integrity": "sha512-YvMLqFak/7rt//lPBtEHv3M4sRNA+HGxrhFZ+DQs9K2IkYJbNwVIb8avtJfhDiuaUBX/AW0jnjv48FV8h3u9bQ==",
-      "license": "MIT"
-    },
-    "node_modules/face-api.js/node_modules/node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha512-IHLHYskTc2arMYsHZH82PVX8CSKT5lzb7AXeyO06QnjGDKtkv+pv3mEki6S7reB/x1QPo+YPxQRNEVgR5V/w3Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/face-api.js/node_modules/seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q==",
-      "license": "MIT"
-    },
-    "node_modules/face-api.js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/supercluster": "^7.1.3",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
-    "face-api.js": "^0.22.2",
+    "@vladmandic/face-api": "^1.7.15",
     "lucide-react": "^1.8.0",
     "maplibre-gl": "^5.23.0",
     "motion": "^12.38.0",

--- a/src/app/(app)/matches/page.tsx
+++ b/src/app/(app)/matches/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * /matches — list of mutual matches (patrol #10, 2026-04-24).
+ *
+ * Previously 404 — the route was referenced by BottomNav and FAB actions
+ * but the page component was never created. Patrol navigator caught it.
+ *
+ * Approach: reuse `useConversations` (already returns mutual matches with
+ * the peer profile + last message preview) and render a grid of avatar
+ * tiles that each link to `/chat/[conversationId]`. Keeps the layout
+ * light — /chat (full conversation thread list) remains the richer view.
+ *
+ * Empty state ships with a clear CTA back to `/browse` so a fresh user
+ * never dead-ends here.
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import { m } from "motion/react";
+import { useConversations } from "@/lib/useConversations";
+import type { ConversationPreview } from "@/lib/useConversations";
+import { MODES, type ModeKey } from "@/lib/modes";
+import { springs } from "@/lib/motion-design";
+import PageHeader from "@/components/ui/PageHeader";
+import EmptyState from "@/components/ui/EmptyState";
+
+function avatarColor(mode: string | null): string {
+  if (!mode || !(mode in MODES)) return "var(--color-accent)";
+  return MODES[mode as ModeKey].color;
+}
+
+function MatchTile({ convo }: { convo: ConversationPreview }) {
+  const color = avatarColor(convo.mode);
+  return (
+    <m.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={springs.snap}
+      className="flex flex-col items-center gap-2"
+    >
+      <Link
+        href={`/chat/${convo.id}`}
+        className="group relative block w-full"
+        aria-label={`Ouvrir le chat avec ${convo.peer.name}`}
+      >
+        <div className="aspect-square w-full rounded-2xl overflow-hidden ring-1 ring-border bg-card transition-shadow group-hover:shadow-lg">
+          {convo.peer.avatar_url ? (
+            <Image
+              src={convo.peer.avatar_url}
+              alt={convo.peer.name}
+              width={160}
+              height={160}
+              className="w-full h-full object-cover"
+              sizes="(max-width: 440px) 45vw, 180px"
+            />
+          ) : (
+            <div
+              className="w-full h-full flex items-center justify-center text-4xl font-bold text-white"
+              style={{ background: color }}
+              aria-hidden="true"
+            >
+              {convo.peer.name[0]}
+            </div>
+          )}
+        </div>
+      </Link>
+      <span className="text-sm font-medium truncate w-full text-center">
+        {convo.peer.name}
+      </span>
+    </m.div>
+  );
+}
+
+export default function MatchesPage() {
+  const { conversations, loading } = useConversations();
+
+  return (
+    <div className="min-h-screen bg-bg pb-20">
+      <PageHeader title="Mes matches" backHref="/feed" />
+
+      <div className="px-4 pt-4">
+        {loading && (
+          <div className="grid grid-cols-2 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="aspect-square rounded-2xl bg-card animate-pulse"
+                aria-hidden="true"
+              />
+            ))}
+          </div>
+        )}
+
+        {!loading && conversations.length === 0 && (
+          <div className="pt-8">
+            <EmptyState
+              emoji="💫"
+              title="Aucun match pour l'instant"
+              subtitle="Commence à swiper pour rencontrer des profils autour de toi ce soir."
+              actionLabel="Découvrir"
+              actionHref="/browse"
+            />
+          </div>
+        )}
+
+        {!loading && conversations.length > 0 && (
+          <div className="grid grid-cols-2 gap-3" role="list">
+            {conversations.map((convo) => (
+              <div key={convo.id} role="listitem">
+                <MatchTile convo={convo} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -15,14 +14,28 @@ export default function ForgotPasswordPage() {
     setLoading(true);
     setError("");
 
-    const { error: err } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/reset-password`,
-    });
-
-    if (err) {
-      setError(err.message);
-    } else {
-      setSent(true);
+    // 2026-04-24 patrol #7 (SEC-006): route through the server wrapper
+    // instead of calling supabase.auth directly. The wrapper rate-limits
+    // to 3 / 15min / (IP + email) — prevents email-bomb + enumeration.
+    try {
+      const res = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          redirectTo: `${window.location.origin}/reset-password`,
+        }),
+      });
+      if (res.status === 429) {
+        setError("Trop de tentatives. Réessaie dans quelques minutes.");
+      } else if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? "Impossible d'envoyer l'email");
+      } else {
+        setSent(true);
+      }
+    } catch {
+      setError("Impossible d'envoyer l'email. Vérifie ta connexion.");
     }
     setLoading(false);
   }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,78 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+import { checkRateLimit, rateLimitResponse, getClientIp } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/auth/forgot-password
+ *
+ * 2026-04-24 patrol #7 (was SEC-006). Wraps `supabase.auth.resetPasswordForEmail`
+ * server-side so we can rate-limit it before the email-send fires. The
+ * previous /forgot-password page called the Supabase client directly with
+ * no throttle — an email-bomb vector and a weak account-enumeration channel.
+ *
+ * Rate limit: 3 requests per 15 minutes per (IP + normalized email).
+ * Intentionally returns the same 200 response regardless of whether the email
+ * exists — prevents enumeration. Supabase also never errors for missing
+ * addresses, so this is consistent with what users already see.
+ */
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface Body {
+  email?: string;
+  redirectTo?: string;
+}
+
+export async function POST(request: Request) {
+  const ip = getClientIp(request);
+
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Corps JSON invalide" }, { status: 400 });
+  }
+
+  const email = (body.email ?? "").trim().toLowerCase();
+  if (!email || !EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: "Email invalide" }, { status: 400 });
+  }
+
+  // 3 attempts / 15 min / (ip + email) — prevents both IP-broadcast and
+  // single-email-targeted bombing.
+  const rl = await checkRateLimit(`forgot:${ip}:${email}`, 3, 15 * 60_000);
+  if (!rl.ok) return rateLimitResponse(rl);
+
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    logger.error("api_forgot_missing_env");
+    return NextResponse.json(
+      { error: "Configuration serveur incomplète" },
+      { status: 500 },
+    );
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false },
+  });
+
+  const redirectTo =
+    typeof body.redirectTo === "string" && body.redirectTo.startsWith("http")
+      ? body.redirectTo
+      : undefined;
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo,
+  });
+
+  if (error) {
+    // Log server-side but never leak to the client — same response shape
+    // whether the email exists or not.
+    logger.warn("api_forgot_supabase_error", { err: error.message });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,110 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+import {
+  checkRateLimitByAction,
+  rateLimitResponse,
+  getClientIp,
+} from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/auth/signup
+ *
+ * 2026-04-24 patrol #7 (was SEC-007). Wraps `supabase.auth.signUp`
+ * server-side so we can rate-limit it. Previously AuthContext called
+ * `supabase.auth.signUp` directly in the browser with no throttle — a
+ * bot army with leaked invite codes could flood the user base.
+ *
+ * Rate limit: 3 signups per hour per IP (via the existing
+ * `namedLimiters.signup` profile, already wired in src/lib/rate-limit.ts).
+ *
+ * The client still owns the session state — we return the access + refresh
+ * tokens from Supabase and the client calls `supabase.auth.setSession()`
+ * so it stays in sync without round-tripping every request through this
+ * route.
+ */
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface Body {
+  email?: string;
+  password?: string;
+  metadata?: {
+    name?: string;
+    age?: number;
+    gender?: string;
+    looking_for?: string;
+  };
+}
+
+export async function POST(request: Request) {
+  const ip = getClientIp(request);
+
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Corps JSON invalide" }, { status: 400 });
+  }
+
+  const email = (body.email ?? "").trim().toLowerCase();
+  const password = body.password ?? "";
+
+  if (!email || !EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: "Email invalide" }, { status: 400 });
+  }
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: "Le mot de passe doit faire au moins 8 caractères" },
+      { status: 400 },
+    );
+  }
+
+  // 3 signups per hour per IP. Uses the prebuilt `signup` named limiter.
+  // Signature is (key, action) — the ip goes first, not the action.
+  const rl = await checkRateLimitByAction(`signup:${ip}`, "signup");
+  if (!rl.ok) return rateLimitResponse(rl);
+
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    logger.error("api_signup_missing_env");
+    return NextResponse.json(
+      { error: "Configuration serveur incomplète" },
+      { status: 500 },
+    );
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false },
+  });
+
+  const metadata = body.metadata && typeof body.metadata === "object"
+    ? body.metadata
+    : undefined;
+
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { data: metadata },
+  });
+
+  if (error) {
+    logger.warn("api_signup_supabase_error", { err: error.message });
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  // Return what the client needs to set its own session. If Supabase is
+  // configured to require email confirmation, `session` will be null and the
+  // client will show the confirmation-sent state.
+  return NextResponse.json({
+    user: data.user,
+    session: data.session
+      ? {
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token,
+        }
+      : null,
+  });
+}

--- a/src/components/profile/SelfieVerification.tsx
+++ b/src/components/profile/SelfieVerification.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 /**
- * SelfieVerification — V5 Wave 15 real selfie verification via face-api.js
+ * SelfieVerification — V5 Wave 15 real selfie verification via @vladmandic/face-api
+ * (formerly face-api.js; swapped 2026-04-24 patrol #8 to drop the
+ * node-fetch@<2.6.7 CVE (GHSA-r683-j2x4-v87g, CVSS 8.8 high). The maintained
+ * fork ships the same browser API with no node-fetch dep.)
  *
  * Flow:
  *   1. Capture 3 random poses (look left, smile, nod up) — liveness proxy
@@ -72,7 +75,7 @@ export default function SelfieVerification({ userId, avatarUrl, onComplete }: Pr
   const loadFaceApi = useCallback(async () => {
     if (faceApiRef.current) return faceApiRef.current;
     try {
-      const faceapi = await import("face-api.js").catch(() => null);
+      const faceapi = await import("@vladmandic/face-api").catch(() => null);
       if (!faceapi) {
         logger.warn("face_api_missing");
         return null;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -86,20 +86,56 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signUp = useCallback(async (email: string, password: string, metadata: { name: string; age: number; gender: string; looking_for: string }) => {
     setLoading(true);
     setError(null);
-    const { data, error: err } = await supabase.auth.signUp({ email, password, options: { data: metadata } });
 
-    if (err) {
-      setError(err.message);
+    // 2026-04-24 patrol #7 (SEC-007): route through the server wrapper
+    // instead of calling supabase.auth.signUp directly. The wrapper rate-limits
+    // to 3 / hour / IP via the prebuilt `signup` limiter — deters bot flooding
+    // with leaked invite codes.
+    let res: Response;
+    try {
+      res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, metadata }),
+      });
+    } catch {
+      setError("Problème de connexion. Réessaie.");
       setLoading(false);
       return null;
+    }
+
+    if (res.status === 429) {
+      setError("Trop de tentatives. Réessaie dans une heure.");
+      setLoading(false);
+      return null;
+    }
+
+    const payload = (await res.json().catch(() => ({}))) as {
+      user?: User | null;
+      session?: { access_token: string; refresh_token: string } | null;
+      error?: string;
+    };
+
+    if (!res.ok) {
+      setError(payload.error ?? "Inscription refusée");
+      setLoading(false);
+      return null;
+    }
+
+    // If email confirmation is disabled, set the session locally so the user
+    // is authenticated in this tab without a second round-trip. If it's
+    // required, `session` is null and the UI shows the "verify your email"
+    // state via the caller page.
+    if (payload.session) {
+      await supabase.auth.setSession(payload.session);
     }
 
     // Profile is auto-created by DB trigger on auth.users INSERT
     // (handle_new_user function with SECURITY DEFINER)
 
-    setUser(data.user);
+    setUser(payload.user ?? null);
     setLoading(false);
-    return data.user;
+    return payload.user ?? null;
   }, []);
 
   const signIn = useCallback(async (email: string, password: string) => {

--- a/src/lib/useHotspots.ts
+++ b/src/lib/useHotspots.ts
@@ -78,27 +78,24 @@ export function useHotspots() {
 
   const { data, loading, refetch } = useAsyncResource<LiveHotspot[]>(
     async (signal) => {
-      // Fetch all online profiles with a known location.
-      // NOTE: RLS on `profiles` should allow reading (id, latitude, longitude,
-      // is_online) for authenticated users. If the schema uses a single
-      // `location` geography column instead, adapt the select here.
-      let onlineProfiles: OnlineProfileLoc[] = [];
-
-      try {
-        const { data: profiles, error } = await supabase
-          .from("profiles")
-          .select("id, latitude, longitude")
-          .eq("is_online", true)
-          .not("latitude", "is", null)
-          .not("longitude", "is", null)
-          .abortSignal(signal);
-
-        if (!error && profiles) {
-          onlineProfiles = profiles as OnlineProfileLoc[];
-        }
-      } catch {
-        // Fall through — we'll return count=0 for every hotspot below.
-      }
+      // 2026-04-24 (patrol #11): the original query selected
+      // `latitude, longitude` from `profiles`, but the schema uses a
+      // PostGIS `location GEOGRAPHY(POINT, 4326)` single column.
+      // The query always returned HTTP 400 — the try/catch below hid
+      // the crash but produced a 400 on every 60s poll, polluting logs.
+      //
+      // Short-term: short-circuit the fetch. Hotspots render with
+      // count=0 which is honest (we don't know live activity here).
+      //
+      // Medium-term: add an SQL RPC `online_hotspot_profiles(radius_m)`
+      // that returns ST_X/ST_Y of online profile locations **rounded
+      // to 100m grid** (so we stay privacy-safe — ties into SEC-001).
+      //
+      // Tracked as part of the GPS privacy cluster (issues #5, #11).
+      // Using `signal` here would be unused; marking it so eslint stops
+      // complaining after the short-circuit:
+      void signal;
+      const onlineProfiles: OnlineProfileLoc[] = [];
 
       const live: LiveHotspot[] = HOTSPOTS.map((h: Hotspot) => {
         // Count profiles within this hotspot's radius.


### PR DESCRIPTION
## Summary

Second sweep of the 2026-04-24 post-glowup patrol backlog. Closes 5 tracked issues in 4 commits.

| Issue | Commit | Scope |
|---|---|---|
| #11 | `17b34ad` | `useHotspots` short-circuit broken `profiles.latitude` query |
| #8 | `6cea1a7` | swap `face-api.js` → `@vladmandic/face-api` (drops CVSS 8.8 CVE) |
| #7 | `8422da6` | wrap signup + forgot-password through `/api/auth/*` rate-limited routes |
| #10 | `18c6591` | create `/matches` page (was 404) |
| #12 | — | closed as false alarm (patrol hallucinated) |
| #14 | — | closed as false alarm (patrol hallucinated) |

Total: **9 files, +404/-105 LOC**, 4 focused commits.

## Details

### #11 — useHotspots short-circuit
The hook was selecting `id, latitude, longitude` from `profiles`, but the schema uses PostGIS `location GEOGRAPHY(POINT, 4326)`. Every 60s poll produced HTTP 400 — the surrounding try/catch hid the crash but spammed the logs. Short-circuited the fetch; hotspots render with count=0 (honest). Proper fix tracked in the GPS privacy cluster (#5).

### #8 — face-api.js CVE
`face-api.js@>=0.20.1` drags `node-fetch@<2.6.7` (GHSA-r683-j2x4-v87g, CVSS 8.8 high). Swapped to `@vladmandic/face-api` — maintained fork, same browser API, no `node-fetch` dep. `npm audit` now returns **0 vulnerabilities** (was 1 high + 2 low). Single import-string change.

### #7 — Auth rate-limit wrappers
Both `/forgot-password` and `AuthContext.signUp` called `supabase.auth` directly from the browser with no throttle — email-bomb (SEC-006) and bot-signup (SEC-007) vectors.

- `/api/auth/forgot-password` rate-limits **3 req / 15min / (IP + email)**
- `/api/auth/signup` rate-limits **3 req / hour / IP** (via the prebuilt `signup` named limiter)
- Signup returns `access_token + refresh_token` — client calls `supabase.auth.setSession()` itself so AuthContext stays the single session source.

### #10 — /matches page
Route was linked from BottomNav and FAB but the page component never existed — every click 404'd. Minimum viable grid: 2-column avatar tiles from `useConversations`, links to `/chat/[id]`, empty state with "Découvrir" CTA to `/browse`. Full conversation view stays on `/chat`.

### #12 + #14 — False alarms (closed)
Both claims came from the console-monitor agent whose `crawl.js` **had no `page.on('console', ...)` listener**. All 9 hydration entries had `stack: null` and the realtime-race claim was inferred from agent context, not observed. Live HTML on `/why-free` is clean; codebase hydration hygiene is actually strong (PageTransition mounted gate + defensive ReducedMotion provider). The `useRealtimeChannel` hook in `useSupabaseQuery.ts` correctly chains `.on()` → `.subscribe()`.

## Validation

```
npx tsc --noEmit            → 0 errors
npm run test:run            → 33 files · 220 / 220 pass
npm run build               → ✓ Compiled successfully in 9.8s
npm audit                   → 0 vulnerabilities (was 1 high)
```

## Remaining backlog (not in this PR)

| Issue | Reason deferred |
|---|---|
| #5 SEC-001 GPS stalking | Requires Supabase migration 024, high blast radius — needs user review first |
| #6 SEC-004 blocks don't block | Pairs with #5, same migration |
| #13 phone-frame layout | Needs visual verification across 8 pages — user eyeball pass before merge |