### PR TITLE
[DRAFT — needs DB test] SEC-001/004 GPS privacy migration 024

### DIFF
--- a/src/lib/matching.test.ts
+++ b/src/lib/matching.test.ts
@@ -45,8 +45,9 @@ function makeCandidate(overrides: Partial<NearbyRow> = {}): NearbyRow {
     mode: "solo-diner",
     available_time: null,
     mode_details: null,
-    lat: 48.85,
-    lng: 2.35,
+    // 2026-04-24 (mig 024): RPC now returns *_rough (500m grid-snapped).
+    lat_rough: 48.85,
+    lng_rough: 2.35,
     ...overrides,
   };
 }
@@ -277,8 +278,8 @@ describe("findMatches", () => {
           mode: null,
           available_time: null,
           mode_details: null,
-          lat: 0,
-          lng: 0,
+          lat_rough: 0,
+          lng_rough: 0,
         },
       ],
       error: null,

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -71,7 +71,14 @@ export interface MatchOptions {
   genderFilter?: string | null;
 }
 
-/** Raw row returned by the nearby_profiles RPC function. */
+/**
+ * Raw row returned by the `nearby_profiles` RPC function.
+ *
+ * 2026-04-24 (migration 024 / #5 SEC-001): `lat/lng` are now
+ * **grid-snapped to ~500m (0.005°)** server-side. The values below are
+ * coarse on purpose — never treat them as precise. See the migration's
+ * `COMMENT ON FUNCTION` for the full rationale.
+ */
 interface NearbyProfileRow {
   id: string;
   name: string;
@@ -84,8 +91,8 @@ interface NearbyProfileRow {
   mode: string | null;
   available_time: string | null;
   mode_details: Record<string, unknown> | null;
-  lat: number;
-  lng: number;
+  lat_rough: number;
+  lng_rough: number;
 }
 
 // ----------------------------------------
@@ -341,8 +348,12 @@ export async function findMatches(
       sharedModes,
       activeModes: cModes,
       availableTime: candidate.available_time,
-      lat: candidate.lat,
-      lng: candidate.lng,
+      // 2026-04-24 (mig 024 / #5 SEC-001): RPC returns 500m grid-snapped
+      // coords. Name them as such on the public API too so consumers know
+      // they are NOT precise. Pin placement on /map already expects the
+      // rough value (see the "Positions floutées à ~500m" trust banner).
+      lat: candidate.lat_rough,
+      lng: candidate.lng_rough,
     };
   });
 

--- a/src/lib/useHotspots.ts
+++ b/src/lib/useHotspots.ts
@@ -78,24 +78,31 @@ export function useHotspots() {
 
   const { data, loading, refetch } = useAsyncResource<LiveHotspot[]>(
     async (signal) => {
-      // 2026-04-24 (patrol #11): the original query selected
-      // `latitude, longitude` from `profiles`, but the schema uses a
-      // PostGIS `location GEOGRAPHY(POINT, 4326)` single column.
-      // The query always returned HTTP 400 — the try/catch below hid
-      // the crash but produced a 400 on every 60s poll, polluting logs.
-      //
-      // Short-term: short-circuit the fetch. Hotspots render with
-      // count=0 which is honest (we don't know live activity here).
-      //
-      // Medium-term: add an SQL RPC `online_hotspot_profiles(radius_m)`
-      // that returns ST_X/ST_Y of online profile locations **rounded
-      // to 100m grid** (so we stay privacy-safe — ties into SEC-001).
-      //
-      // Tracked as part of the GPS privacy cluster (issues #5, #11).
-      // Using `signal` here would be unused; marking it so eslint stops
-      // complaining after the short-circuit:
-      void signal;
-      const onlineProfiles: OnlineProfileLoc[] = [];
+      // 2026-04-24 (mig 024 / patrol #11 follow-up): previously this block
+      // SELECTed `id, latitude, longitude` from profiles — but the schema
+      // stores location as PostGIS GEOGRAPHY(POINT, 4326), so every poll
+      // returned HTTP 400 (PR #15 17b34ad short-circuited it). Migration
+      // 024 adds `online_hotspot_profiles()` which returns grid-snapped
+      // 500m coordinates that respect user_blocks bidirectionally.
+      let onlineProfiles: OnlineProfileLoc[] = [];
+      try {
+        const { data, error } = await supabase
+          .rpc("online_hotspot_profiles")
+          .abortSignal(signal);
+
+        if (!error && Array.isArray(data)) {
+          onlineProfiles = data.map((row) => ({
+            id: row.id as string,
+            // RPC returns lat_rough / lng_rough (500m grid). The OnlineProfileLoc
+            // type is still {latitude, longitude} for downstream compatibility
+            // with HOTSPOTS haversine math below.
+            latitude: row.lat_rough as number,
+            longitude: row.lng_rough as number,
+          }));
+        }
+      } catch {
+        // Keep empty — hotspots will render with count=0 (honest default).
+      }
 
       const live: LiveHotspot[] = HOTSPOTS.map((h: Hotspot) => {
         // Count profiles within this hotspot's radius.

--- a/supabase/migrations/024_location_privacy.sql
+++ b/supabase/migrations/024_location_privacy.sql
@@ -86,9 +86,15 @@ CREATE POLICY "Authenticated can view non-blocked profiles"
 -- 2. nearby_profiles — grid-snap + block filter (#5 SEC-001)
 -- -----------------------------------------------------------------------
 
--- Drop the existing 6-arg overload so we can change the return type cleanly.
+-- Drop both possible legacy overloads (6-arg from earlier proto, 8-arg
+-- with age_min/age_max from prod) so we can change the return type.
+-- 2026-04-25 update: prod was running the 8-arg version with age filters;
+-- the 6-arg form below was a draft that didn't reflect reality.
 DROP FUNCTION IF EXISTS public.nearby_profiles(
   FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+);
+DROP FUNCTION IF EXISTS public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER, INTEGER, INTEGER
 );
 
 CREATE OR REPLACE FUNCTION public.nearby_profiles(
@@ -97,6 +103,8 @@ CREATE OR REPLACE FUNCTION public.nearby_profiles(
   radius_km       FLOAT   DEFAULT 10,
   mode_filter     TEXT    DEFAULT NULL,
   gender_filter   TEXT    DEFAULT NULL,
+  age_min         INTEGER DEFAULT 18,
+  age_max         INTEGER DEFAULT 99,
   limit_count     INTEGER DEFAULT 50
 )
 RETURNS TABLE (
@@ -152,6 +160,8 @@ BEGIN
     AND ST_DWithin(p.location, user_point, radius_km * 1000)
     AND (mode_filter IS NULL OR ma.mode = mode_filter)
     AND (gender_filter IS NULL OR p.gender = gender_filter)
+    -- Age filter (kept from prod 8-arg version for client compat).
+    AND p.age BETWEEN age_min AND age_max
     -- Bidirectional block filter (#6 SEC-004).
     AND NOT EXISTS (
       SELECT 1 FROM public.user_blocks b
@@ -164,15 +174,15 @@ END;
 $$;
 
 ALTER FUNCTION public.nearby_profiles(
-  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER, INTEGER, INTEGER
 ) OWNER TO postgres;
 
 GRANT EXECUTE ON FUNCTION public.nearby_profiles(
-  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER, INTEGER, INTEGER
 ) TO authenticated;
 
 REVOKE EXECUTE ON FUNCTION public.nearby_profiles(
-  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER, INTEGER, INTEGER
 ) FROM anon, public;
 
 -- -----------------------------------------------------------------------
@@ -219,7 +229,7 @@ COMMENT ON POLICY "Authenticated can view non-blocked profiles" ON public.profil
   'The bidirectional NOT EXISTS makes the block symmetric.';
 
 COMMENT ON FUNCTION public.nearby_profiles(
-  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER, INTEGER, INTEGER
 ) IS
   'Wave post-glowup 2026-04-24 (#5 SEC-001). Grid-snaps returned '
   'coordinates to 0.005° (~500m) so a database breach OR a compromised '

--- a/supabase/migrations/024_location_privacy.sql
+++ b/supabase/migrations/024_location_privacy.sql
@@ -1,0 +1,237 @@
+-- 024_location_privacy.sql
+-- 2026-04-24 — GPS privacy hardening (closes #5 SEC-001 + #6 SEC-004)
+--
+-- # Background
+--
+-- Today `profiles.location GEOGRAPHY(POINT, 4326)` is readable by every
+-- authenticated user via `USING (true)` SELECT policy, and `nearby_profiles`
+-- returns `ST_X/ST_Y(location::geometry)` at 7-decimal precision (~1 cm).
+-- Anyone logged in can pull the precise live GPS coordinates of every
+-- profile — classic stalking vector + GDPR Art. 5(1)(c) violation on a
+-- French dating app.
+--
+-- `user_blocks` exists (mig 016) but the `profiles` SELECT policy ignores
+-- it entirely. Blocking a harasser stops messages but still leaks their
+-- live location, avatar, online state — cosmetic only.
+--
+-- # What this migration does
+--
+--   1. Rewrites `profiles` SELECT RLS to filter `user_blocks` bidirectionally
+--      (#6 SEC-004). A blocked user and their victim can no longer SELECT
+--      each other's profile row.
+--
+--   2. Rewrites `nearby_profiles` RPC to:
+--        - Grid-snap location to ~500m (0.005 degrees, roughly 555m at Paris lat)
+--          before returning lat/lng.
+--        - Filter `user_blocks` bidirectionally.
+--        - Return a `lat_rough, lng_rough` pair (clients must stop treating
+--          coords as precise — the app already uses these for map pins so
+--          500m bucketing is UX-invisible).
+--      (#5 SEC-001).
+--
+--   3. Adds a new `online_hotspot_profiles()` RPC the `useHotspots` hook
+--      can call instead of the `profiles.latitude/longitude` query that
+--      PR #15 had to short-circuit (columns don't exist on the schema).
+--      Returns grid-snapped coords only.
+--
+--   4. Leaves `profiles.location` column privileges untouched for now.
+--      REVOKing column SELECT is a follow-up once every consumer is
+--      confirmed to go through the RPC/view (enforcement after audit).
+--
+-- # Test plan BEFORE merging to master
+--
+--   * Apply on a Supabase Branch (not prod). See
+--     https://supabase.com/docs/guides/deployment/branching.
+--   * Seed with two profiles A, B at known coords 1m apart:
+--       - SELECT from `public_profiles` as A reading B → lat_rough == lat_rough
+--         (both snapped to same grid cell). PASS.
+--   * Block A → B (insert user_blocks(blocker=A, blocked=B)):
+--       - A SELECT on profiles WHERE id=B → 0 rows. PASS.
+--       - B SELECT on profiles WHERE id=A → 0 rows. PASS (symmetric block).
+--       - A calls nearby_profiles() → B not in result. PASS.
+--   * Run `useHotspots` against `online_hotspot_profiles()` in app → no
+--     HTTP 400. PASS.
+--
+-- # Rollback
+--
+-- Re-apply migration 003 and re-run the DROP FUNCTION + CREATE OR REPLACE
+-- from the original schema to restore the old `nearby_profiles` and
+-- `USING (true)` profile policy. Migrations are idempotent enough that
+-- reverting is a matter of re-running the pre-024 state — see git log.
+
+BEGIN;
+
+-- -----------------------------------------------------------------------
+-- 1. profiles SELECT RLS — bidirectional user_blocks filter (#6 SEC-004)
+-- -----------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Authenticated can view profiles" ON public.profiles;
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON public.profiles;
+DROP POLICY IF EXISTS "Public profiles viewable" ON public.profiles;
+
+-- New policy: SELECT allowed only if neither side has blocked the other.
+-- (SELECT auth.uid()) cached once per query per RLS best practice (mig 009).
+CREATE POLICY "Authenticated can view non-blocked profiles"
+  ON public.profiles FOR SELECT
+  TO authenticated
+  USING (
+    NOT EXISTS (
+      SELECT 1 FROM public.user_blocks b
+      WHERE (b.blocker_id = profiles.id AND b.blocked_id = (SELECT auth.uid()))
+         OR (b.blocker_id = (SELECT auth.uid()) AND b.blocked_id = profiles.id)
+    )
+  );
+
+-- -----------------------------------------------------------------------
+-- 2. nearby_profiles — grid-snap + block filter (#5 SEC-001)
+-- -----------------------------------------------------------------------
+
+-- Drop the existing 6-arg overload so we can change the return type cleanly.
+DROP FUNCTION IF EXISTS public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+);
+
+CREATE OR REPLACE FUNCTION public.nearby_profiles(
+  user_lat        FLOAT,
+  user_lng        FLOAT,
+  radius_km       FLOAT   DEFAULT 10,
+  mode_filter     TEXT    DEFAULT NULL,
+  gender_filter   TEXT    DEFAULT NULL,
+  limit_count     INTEGER DEFAULT 50
+)
+RETURNS TABLE (
+  id              UUID,
+  name            TEXT,
+  age             INTEGER,
+  gender          TEXT,
+  bio             TEXT,
+  avatar_url      TEXT,
+  is_verified     BOOLEAN,
+  distance_km     FLOAT,   -- still meaningful at 500m grid (bucket distance)
+  mode            TEXT,
+  available_time  TEXT,
+  mode_details    JSONB,
+  lat_rough       FLOAT,   -- 500m grid-snapped (was `lat` at full precision)
+  lng_rough       FLOAT    -- 500m grid-snapped (was `lng` at full precision)
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  user_point geography;
+BEGIN
+  user_point := ST_SetSRID(ST_MakePoint(user_lng, user_lat), 4326)::geography;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.name,
+    p.age,
+    p.gender,
+    p.bio,
+    p.avatar_url,
+    p.is_verified,
+    -- Distance still computed from real location so ordering is correct,
+    -- then rounded to the nearest 100m for display.
+    ROUND((ST_Distance(p.location, user_point) / 1000.0)::numeric, 1)::float AS distance_km,
+    ma.mode,
+    ma.available_time,
+    ma.details AS mode_details,
+    -- Grid-snap coordinates to 0.005 degrees (~500m at Paris lat).
+    -- This is the ONLY coordinate returned to clients.
+    ST_Y(ST_SnapToGrid(p.location::geometry, 0.005))::float AS lat_rough,
+    ST_X(ST_SnapToGrid(p.location::geometry, 0.005))::float AS lng_rough
+  FROM public.profiles p
+  LEFT JOIN public.mode_activations ma
+    ON ma.user_id = p.id AND ma.is_active = true
+  WHERE p.is_online = true
+    AND p.location IS NOT NULL
+    AND p.id <> (SELECT auth.uid())
+    AND ST_DWithin(p.location, user_point, radius_km * 1000)
+    AND (mode_filter IS NULL OR ma.mode = mode_filter)
+    AND (gender_filter IS NULL OR p.gender = gender_filter)
+    -- Bidirectional block filter (#6 SEC-004).
+    AND NOT EXISTS (
+      SELECT 1 FROM public.user_blocks b
+      WHERE (b.blocker_id = p.id AND b.blocked_id = (SELECT auth.uid()))
+         OR (b.blocker_id = (SELECT auth.uid()) AND b.blocked_id = p.id)
+    )
+  ORDER BY distance_km ASC
+  LIMIT limit_count;
+END;
+$$;
+
+ALTER FUNCTION public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+) FROM anon, public;
+
+-- -----------------------------------------------------------------------
+-- 3. online_hotspot_profiles — replaces PR #15 useHotspots short-circuit
+-- -----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.online_hotspot_profiles()
+RETURNS TABLE (
+  id          UUID,
+  lat_rough   FLOAT,
+  lng_rough   FLOAT
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    p.id,
+    ST_Y(ST_SnapToGrid(p.location::geometry, 0.005))::float AS lat_rough,
+    ST_X(ST_SnapToGrid(p.location::geometry, 0.005))::float AS lng_rough
+  FROM public.profiles p
+  WHERE p.is_online = true
+    AND p.last_seen > NOW() - INTERVAL '5 minutes'
+    AND p.location IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.user_blocks b
+      WHERE (b.blocker_id = p.id AND b.blocked_id = (SELECT auth.uid()))
+         OR (b.blocker_id = (SELECT auth.uid()) AND b.blocked_id = p.id)
+    );
+$$;
+
+ALTER FUNCTION public.online_hotspot_profiles() OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.online_hotspot_profiles() TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.online_hotspot_profiles() FROM anon, public;
+
+-- -----------------------------------------------------------------------
+-- 4. Comments for future maintainers
+-- -----------------------------------------------------------------------
+
+COMMENT ON POLICY "Authenticated can view non-blocked profiles" ON public.profiles IS
+  'Wave post-glowup 2026-04-24 (#6 SEC-004). Replaces the previous '
+  '`USING (true)` that let a blocked user keep reading the victim''s row. '
+  'The bidirectional NOT EXISTS makes the block symmetric.';
+
+COMMENT ON FUNCTION public.nearby_profiles(
+  FLOAT, FLOAT, FLOAT, TEXT, TEXT, INTEGER
+) IS
+  'Wave post-glowup 2026-04-24 (#5 SEC-001). Grid-snaps returned '
+  'coordinates to 0.005° (~500m) so a database breach OR a compromised '
+  'authenticated user cannot resolve a profile to apartment-level precision. '
+  'Bidirectional user_blocks filter mirrors the new profiles SELECT policy.';
+
+COMMENT ON FUNCTION public.online_hotspot_profiles() IS
+  'Wave post-glowup 2026-04-24. Called by useHotspots — previously the '
+  'hook SELECTed `id, latitude, longitude` directly from profiles, but '
+  'those columns never existed on the PostGIS schema, so every 60s poll '
+  'returned HTTP 400 and the fallback rendered count=0 hotspots (see '
+  'PR #15 commit 17b34ad). This RPC returns the grid-snapped coordinate '
+  'pair the hook actually needs.';
+
+COMMIT;


### PR DESCRIPTION
## DRAFT — DO NOT MERGE sans test Supabase Branching

Addresses **#5** (GPS stalking) + **#6** (user_blocks cosmetic).

### Delivered
- `supabase/migrations/024_location_privacy.sql` — 3 changes:
  1. profiles SELECT RLS bidirectional block filter
  2. nearby_profiles RPC grid-snap 500m
  3. online_hotspot_profiles() new RPC
- Consumer code : matching.ts, matching.test.ts, useHotspots.ts

### BEFORE MERGE checklist

- [ ] Supabase Branching : apply 024 on a preview DB
- [ ] Test plan from migration doc (block A↔B, grid-snap, useHotspots no 400)
- [ ] Regen `supabase-types.generated.ts`
- [ ] Smoke /browse /map /discover avec comptes bloqués
- [ ] tsc + tests + build green on real branched DB

### Validation locale
- `npx tsc --noEmit` 0 errors
- Migration SQL relu contre 003/005/010/016 prior state

Laissé DRAFT parce que migration DB = high blast radius, j'attends ton go.