### PR TITLE
fix: KeyboardShortcuts hydration + EventsWidget infinite loop

### DIFF
--- a/src/components/app/KeyboardShortcuts.tsx
+++ b/src/components/app/KeyboardShortcuts.tsx
@@ -90,18 +90,27 @@ export default function KeyboardShortcuts() {
   const pathname = usePathname();
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
-  // Hint visibility is initialised lazily (render-time) so the localStorage
-  // read happens once per mount without a cascading effect->setState cycle.
-  // SSR-safe: localStorage is only touched on the client (initialiser runs
-  // during the first client render because this is a "use client" file).
-  const [hintVisible, setHintVisible] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
+
+  // 2026-04-24 (hydration fix): the previous "useState initialiser that
+  // reads localStorage on the client, returns false on the server" pattern
+  // was NOT SSR-safe despite the comment — the initialiser DOES run during
+  // the initial client render of a "use client" component (hydration pass),
+  // and if localStorage is empty (first visit) it returns true on the
+  // client while SSR produced false. That introduces a stray
+  // AnimatePresence child in the tree on CSR that wasn't there on SSR, and
+  // React flags it as a hydration mismatch ("server HTML didn't match the
+  // client") that shifts the position of the next sibling (the Toast
+  // container). Fix: use the mounted-gate pattern — always start false
+  // (matches SSR), flip to the real localStorage value in a useEffect
+  // AFTER hydration so the first render is deterministic across runtimes.
+  const [hintVisible, setHintVisible] = useState<boolean>(false);
+  useEffect(() => {
     try {
-      return !localStorage.getItem(HINT_DISMISSED_KEY);
+      setHintVisible(!localStorage.getItem(HINT_DISMISSED_KEY));
     } catch {
-      return false;
+      // Private browsing / quota — leave hint hidden.
     }
-  });
+  }, []);
 
   // g-chord buffer — stores the last "g" press with a timestamp; resets
   // after 800ms of inactivity or when the chord completes.

--- a/src/components/feed/EventsWidget.tsx
+++ b/src/components/feed/EventsWidget.tsx
@@ -27,13 +27,28 @@ import { useAccessibility } from "@/components/ui/ReducedMotion";
  * Subscribe to a 5-minute wall-clock tick. `useSyncExternalStore` is the
  * React-blessed way to read an external value (Date.now()) without tripping
  * the `react-hooks/purity` or `set-state-in-effect` lints.
+ *
+ * 2026-04-24 (dev-mode infinite-loop fix): the snapshot function MUST return
+ * a stable reference between tick notifications, otherwise `useSyncExternalStore`
+ * re-renders the component every millisecond (Date.now() is fresh on each
+ * call). React dev mode detects the loop as "Maximum update depth exceeded".
+ * Cache the value in a module-level variable that only changes inside
+ * `subscribeTick`.
  */
+let cachedNowMs = typeof window === "undefined" ? 0 : Date.now();
+
 function subscribeTick(callback: () => void): () => void {
-  const id = window.setInterval(callback, 5 * 60_000);
+  // Refresh the cache on (re)subscribe so components mounting later see a
+  // fresh value rather than whatever was cached at module load.
+  cachedNowMs = Date.now();
+  const id = window.setInterval(() => {
+    cachedNowMs = Date.now();
+    callback();
+  }, 5 * 60_000);
   return () => window.clearInterval(id);
 }
 function getNowMs(): number {
-  return Date.now();
+  return cachedNowMs;
 }
 function getServerNowMs(): number {
   // SSR fallback — 0 means "skip client-only filters" on the server.


### PR DESCRIPTION
## 2 real bugs caught by running npm run dev after PR #19 unblocked dev mode

### 1. KeyboardShortcuts hydration mismatch
`useState(() => localStorage.getItem(...))` with a 'SSR-safe' comment that was wrong. Fix: mounted-gate pattern (always start false, flip via useEffect).

### 2. EventsWidget infinite loop
`useSyncExternalStore` with `() => Date.now()` as snapshot → new value every ms → React re-renders forever. Fix: cache value module-level, update only inside subscribeTick callback.

## Validation

Playwright 6 routes on localhost:3000, all 0 errors: / /settings /feed /browse /map /profile.

`npx tsc --noEmit` → 0 errors.

Auto-merge OK.