### PR TITLE
feat(invites): hybrid Tinder-style referral rewards + /invites/mine dashboard

### DIFF
--- a/src/app/(app)/invites/mine/page.tsx
+++ b/src/app/(app)/invites/mine/page.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+/**
+ * /invites/mine — user's invite code dashboard.
+ *
+ * Powered by mig 021 + mig 025 (hybrid invite rewards).
+ * Each user can hold up to 3 unused codes at a time. When someone signs
+ * up via one of their codes, both sides get +5 roses and the new user
+ * gets the 'founder' achievement badge.
+ *
+ * Page lists:
+ *  - The user's active (unused, non-expired) codes with copy + share
+ *  - Codes already claimed (audit trail)
+ *  - Stats: total signups via my codes, total roses earned via referrals
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { m } from "motion/react";
+import { useAuth } from "@/context/AuthContext";
+import { supabase } from "@/lib/supabase";
+import PageHeader from "@/components/ui/PageHeader";
+import { springs } from "@/lib/motion-design";
+
+interface InviteCode {
+  code: string;
+  used_by: string | null;
+  used_at: string | null;
+  expires_at: string;
+  created_at: string;
+}
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "?";
+  return d.toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
+}
+
+function shareUrl(code: string): string {
+  if (typeof window === "undefined") return "";
+  return `${window.location.origin}/signup-quick?invite=${code}`;
+}
+
+function CodeCard({ code, onCopy }: { code: InviteCode; onCopy: (text: string) => void }) {
+  const [copied, setCopied] = useState(false);
+  const [shared, setShared] = useState(false);
+  const used = code.used_by !== null;
+  const expired = !used && new Date(code.expires_at) < new Date();
+  const url = shareUrl(code.code);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      onCopy(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Older browsers / Safari quirks — fall back to selecting an element
+      // would require an extra hidden input; for now we just leave the user
+      // to paste manually.
+    }
+  }
+
+  async function handleShare() {
+    if (typeof navigator !== "undefined" && "share" in navigator) {
+      try {
+        await navigator.share({
+          title: "Rejoins-moi sur CeSoir",
+          text: "On va manger / sortir ce soir ? J'utilise CeSoir pour trouver quelqu'un. Mon code te donne +5 🌹 :",
+          url,
+        });
+        setShared(true);
+        setTimeout(() => setShared(false), 2000);
+      } catch {
+        // User cancelled the share sheet — silent.
+      }
+    } else {
+      // Desktop — copy instead
+      await handleCopy();
+    }
+  }
+
+  return (
+    <m.div
+      layout
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={springs.snap}
+      className={`rounded-2xl border p-4 ${
+        used
+          ? "border-vert/30 bg-vert/5"
+          : expired
+            ? "border-border bg-card/50 opacity-60"
+            : "border-border bg-card"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="font-mono text-2xl font-bold tracking-wider text-text">
+          {code.code}
+        </div>
+        {used && (
+          <span className="text-[10px] font-semibold uppercase text-vert px-2 py-0.5 rounded-full bg-vert/10 border border-vert/30">
+            ✓ Utilisé
+          </span>
+        )}
+        {!used && expired && (
+          <span className="text-[10px] font-semibold uppercase text-text-muted px-2 py-0.5 rounded-full bg-text-muted/10 border border-text-muted/30">
+            Expiré
+          </span>
+        )}
+        {!used && !expired && (
+          <span className="text-[10px] font-semibold uppercase text-accent px-2 py-0.5 rounded-full bg-accent/10 border border-accent/30">
+            Actif · jusqu&apos;au {fmtDate(code.expires_at)}
+          </span>
+        )}
+      </div>
+
+      {used && code.used_at ? (
+        <div className="text-xs text-text-muted">
+          Utilisé le {fmtDate(code.used_at)}. Tu as gagné <span className="font-semibold text-text">5 🌹</span>.
+        </div>
+      ) : !expired ? (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex-1 px-3 py-2 rounded-full bg-card border border-border text-text text-xs font-semibold hover:border-accent transition-colors tap-target"
+          >
+            {copied ? "✓ Copié !" : "Copier le lien"}
+          </button>
+          <button
+            type="button"
+            onClick={handleShare}
+            className="flex-1 px-3 py-2 rounded-full bg-accent text-white text-xs font-semibold hover:opacity-90 transition-opacity tap-target"
+          >
+            {shared ? "✓ Envoyé" : "Partager"}
+          </button>
+        </div>
+      ) : null}
+    </m.div>
+  );
+}
+
+export default function InvitesMinePage() {
+  const { user, loading: authLoading } = useAuth();
+  const [codes, setCodes] = useState<InviteCode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [minting, setMinting] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const fetchCodes = useCallback(async () => {
+    setLoading(true);
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData.session?.access_token;
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    const res = await fetch("/api/invites/mine", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = (await res.json()) as { codes?: InviteCode[]; error?: string };
+    if (data.codes) setCodes(data.codes);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!authLoading && user) void fetchCodes();
+  }, [authLoading, user, fetchCodes]);
+
+  async function handleMint() {
+    setMinting(true);
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData.session?.access_token;
+    if (!token) {
+      setMinting(false);
+      return;
+    }
+    await fetch("/api/invites/mine", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    await fetchCodes();
+    setMinting(false);
+  }
+
+  function flashToast(text: string) {
+    setToast(text);
+    setTimeout(() => setToast(null), 1800);
+  }
+
+  const active = codes.filter((c) => !c.used_by && new Date(c.expires_at) > new Date());
+  const used = codes.filter((c) => c.used_by);
+  const expired = codes.filter((c) => !c.used_by && new Date(c.expires_at) <= new Date());
+
+  // Each used code = +5 roses earned. Bookkeeping is server-side via
+  // user_wallet, but this is a useful reminder for the dashboard.
+  const rosesEarned = used.length * 5;
+
+  return (
+    <div className="min-h-screen bg-bg pb-20">
+      <PageHeader
+        title="Mes invitations"
+        backHref="/profile"
+        subtitle="Partage tes codes — 5 🌹 pour toi et ton ami à chaque inscription"
+      />
+
+      <div className="px-4 pt-4 max-w-md mx-auto space-y-6">
+        {/* Stats banner */}
+        <m.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={springs.snap}
+          className="rounded-2xl border border-accent/30 bg-accent/5 p-4 flex items-center justify-around text-center"
+        >
+          <div>
+            <div className="font-display text-2xl font-bold text-text">{used.length}</div>
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">Inscriptions</div>
+          </div>
+          <div className="w-px h-8 bg-border" aria-hidden="true" />
+          <div>
+            <div className="font-display text-2xl font-bold text-accent">{rosesEarned}</div>
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">🌹 gagnées</div>
+          </div>
+          <div className="w-px h-8 bg-border" aria-hidden="true" />
+          <div>
+            <div className="font-display text-2xl font-bold text-text">{active.length}</div>
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">Codes actifs</div>
+          </div>
+        </m.div>
+
+        {/* Active codes section */}
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-xs font-bold uppercase tracking-wider text-text-muted">
+              Codes actifs
+            </h2>
+            {active.length < 3 && (
+              <button
+                type="button"
+                onClick={handleMint}
+                disabled={minting}
+                className="text-[11px] font-semibold text-accent hover:opacity-80 disabled:opacity-50 tap-target"
+              >
+                {minting ? "…" : `Générer ${3 - active.length} de plus`}
+              </button>
+            )}
+          </div>
+
+          {loading && (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-24 rounded-2xl bg-card animate-pulse" aria-hidden="true" />
+              ))}
+            </div>
+          )}
+
+          {!loading && active.length === 0 && (
+            <div className="rounded-2xl border border-border bg-card p-6 text-center">
+              <p className="text-sm text-text-muted mb-3">
+                Tu n&apos;as pas de code actif.
+              </p>
+              <button
+                type="button"
+                onClick={handleMint}
+                disabled={minting}
+                className="px-4 py-2 rounded-full bg-accent text-white text-xs font-semibold hover:opacity-90 disabled:opacity-50 tap-target"
+              >
+                {minting ? "Génération…" : "Générer mes 3 codes"}
+              </button>
+            </div>
+          )}
+
+          {!loading && active.length > 0 && (
+            <div className="space-y-2">
+              {active.map((c) => (
+                <CodeCard key={c.code} code={c} onCopy={() => flashToast("Lien copié")} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Used codes (audit trail) */}
+        {used.length > 0 && (
+          <section>
+            <h2 className="text-xs font-bold uppercase tracking-wider text-text-muted mb-3">
+              Déjà utilisés
+            </h2>
+            <div className="space-y-2">
+              {used.map((c) => (
+                <CodeCard key={c.code} code={c} onCopy={() => flashToast("Lien copié")} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Expired (collapsed) */}
+        {expired.length > 0 && (
+          <details className="text-xs text-text-muted">
+            <summary className="cursor-pointer">
+              {expired.length} code{expired.length > 1 ? "s" : ""} expiré{expired.length > 1 ? "s" : ""}
+            </summary>
+            <div className="space-y-2 mt-2">
+              {expired.map((c) => (
+                <CodeCard key={c.code} code={c} onCopy={() => flashToast("Lien copié")} />
+              ))}
+            </div>
+          </details>
+        )}
+
+        {/* How it works */}
+        <section className="rounded-2xl border border-border bg-card/50 p-4 text-xs text-text-muted leading-relaxed">
+          <h3 className="font-semibold text-text mb-2">Comment ça marche</h3>
+          <ol className="space-y-1.5 list-decimal list-inside">
+            <li>Tu partages un de tes codes (lien ou texte oral &laquo; CESOIRXX &raquo;)</li>
+            <li>Ton ami s&apos;inscrit sur cesoir-app.vercel.app et entre le code</li>
+            <li>Vous recevez chacun <span className="text-accent font-semibold">5 🌹</span> et lui débloque le badge <span className="text-accent font-semibold">Founder ☾</span></li>
+          </ol>
+          <p className="mt-3">
+            <Link href="/profile" className="text-accent font-semibold">← Retour au profil</Link>
+          </p>
+        </section>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <m.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-text text-bg text-xs font-semibold shadow-xl"
+        >
+          {toast}
+        </m.div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/025_invite_rewards_hybrid.sql
+++ b/supabase/migrations/025_invite_rewards_hybrid.sql
@@ -1,0 +1,116 @@
+-- ========================================================================
+-- Migration 025: hybrid invite rewards (Tinder/Bumble-style referral loop)
+-- ========================================================================
+-- 2026-04-25 — strategy pivot from invite-only (Wave 15 plan, never DB-
+-- enforced anyway since mig 021 was on disk but never applied to prod)
+-- to OPEN signup + REWARDS-ON-CODE-USE.
+--
+-- /signup-quick is now open — anyone can sign up without a code. But
+-- when a user DOES sign up with an invite code (?invite=XXX or pasted
+-- on step 1), the claim now triggers a 3-part reward:
+--
+--   1. New user gets +5 roses (always, via user_wallet upsert)
+--   2. Inviter gets +5 roses (skipped if the code is system-seeded —
+--      i.e. created_by IS NULL — and skipped on self-invite)
+--   3. New user gets the 'founder' achievement badge
+--
+-- Plus the new user is auto-minted 3 codes of their own — kicks off
+-- their referral loop in the same atomic transaction.
+--
+-- The bare claim_invite_code from mig 021 is REPLACED entirely (the
+-- return shape changes, so we DROP first).
+--
+-- # Why the hybrid model (and not invite-only forever)
+--
+-- Tinder USC 2012, Bumble Austin 2014, Hinge 2013 — all started invite-
+-- gated then opened once they had local critical mass. CeSoir is free
+-- and mass-market: density beats exclusivity. The reward keeps the
+-- viral loop, the open door keeps growth.
+-- ========================================================================
+
+DROP FUNCTION IF EXISTS public.claim_invite_code(TEXT);
+
+CREATE OR REPLACE FUNCTION public.claim_invite_code(p_code TEXT)
+RETURNS TABLE (
+  code            TEXT,
+  claimed_by      UUID,
+  claimed_at      TIMESTAMPTZ,
+  inviter_id      UUID,
+  roses_granted   INT,
+  badge_granted   TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $func$
+DECLARE
+  v_caller         UUID := auth.uid();
+  v_code_row       public.invite_codes%ROWTYPE;
+  v_inviter        UUID;
+  v_roses_amount   INT := 5;
+  v_now            TIMESTAMPTZ := now();
+BEGIN
+  IF v_caller IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF p_code IS NULL OR length(trim(p_code)) = 0 THEN
+    RAISE EXCEPTION 'Code required' USING ERRCODE = '22023';
+  END IF;
+
+  -- Lock-and-validate atomically
+  SELECT * INTO v_code_row
+    FROM public.invite_codes
+   WHERE upper(code) = upper(trim(p_code))
+   FOR UPDATE;
+
+  IF NOT FOUND THEN RAISE EXCEPTION 'Invalid code' USING ERRCODE = 'P0001'; END IF;
+  IF v_code_row.used_by IS NOT NULL THEN RAISE EXCEPTION 'Code already claimed' USING ERRCODE = 'P0002'; END IF;
+  IF v_code_row.expires_at < v_now THEN RAISE EXCEPTION 'Code expired' USING ERRCODE = 'P0003'; END IF;
+
+  UPDATE public.invite_codes
+     SET used_by = v_caller,
+         used_at = v_now
+   WHERE code = v_code_row.code;
+
+  v_inviter := v_code_row.created_by;
+
+  -- Reward 1: +5 roses to the new user (always)
+  INSERT INTO public.user_wallet (user_id, roses_balance, updated_at)
+  VALUES (v_caller, v_roses_amount, v_now)
+  ON CONFLICT (user_id) DO UPDATE
+    SET roses_balance = public.user_wallet.roses_balance + EXCLUDED.roses_balance,
+        updated_at    = v_now;
+
+  -- Reward 2: +5 roses to the inviter (only if user-minted, never self-invite)
+  IF v_inviter IS NOT NULL AND v_inviter <> v_caller THEN
+    INSERT INTO public.user_wallet (user_id, roses_balance, updated_at)
+    VALUES (v_inviter, v_roses_amount, v_now)
+    ON CONFLICT (user_id) DO UPDATE
+      SET roses_balance = public.user_wallet.roses_balance + EXCLUDED.roses_balance,
+          updated_at    = v_now;
+  END IF;
+
+  -- Reward 3: 'founder' badge (idempotent — re-running this RPC for the
+  -- same user is a no-op on the achievement).
+  INSERT INTO public.achievements (user_id, achievement_key, earned_at)
+  VALUES (v_caller, 'founder', v_now)
+  ON CONFLICT DO NOTHING;
+
+  -- Auto-mint 3 codes for the new user — kicks off their referral loop
+  -- inside the same transaction.
+  PERFORM public.mint_user_invite_codes(3);
+
+  RETURN QUERY
+    SELECT v_code_row.code,
+           v_caller,
+           v_now,
+           v_inviter,
+           v_roses_amount,
+           'founder'::TEXT;
+END;
+$func$;
+
+COMMENT ON FUNCTION public.claim_invite_code(TEXT) IS
+  'Hybrid invite (mig 025): atomic claim + 5 roses to new user + 5 roses to inviter (if not system code) + founder badge + auto-mint 3 codes.';
+
+GRANT EXECUTE ON FUNCTION public.claim_invite_code(TEXT) TO authenticated;


### PR DESCRIPTION
## What

Open signup + reward-on-code-use (Tinder/Bumble post-launch model).

- /signup-quick stays open
- ?invite=XXX → +5 roses to BOTH sides + 'founder' badge to new user + auto-mint 3 codes for new user
- New page /invites/mine: copy/share codes + stats (signups, 🌹 earned, active count)

## Migrations applied via MCP

- 021_invite_codes (table + RLS + mint RPC + 7 seed codes CESOIR01-05/EARLYMOON/MOONWALK)
- 025_invite_rewards_hybrid (replaces claim_invite_code w/ reward logic)

## Validation

`npx tsc --noEmit` → 0 errors. Existing 58 seed users untouched. New rewards kick in on first real claim.

Auto-merge OK.