### PR TITLE
feat(badges): show Founder chip on SwipeCard

### DIFF
--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -46,6 +46,7 @@ function candidateToProfile(c: MatchCandidate): Profile {
     time: c.availableTime ?? "Dispo maintenant",
     color: "var(--color-accent)",
     photo: c.avatar_url ?? `https://ui-avatars.com/api/?name=${encodeURIComponent(c.name || "?")}&background=8B5CF6&color=fff&bold=true&size=256&format=svg`,
+    is_founder: c.is_founder,
   };
 }
 

--- a/src/components/app/SwipeCard.tsx
+++ b/src/components/app/SwipeCard.tsx
@@ -153,10 +153,30 @@ export default function SwipeCard({
         </div>
       </div>
 
-      {/* Mode badge */}
-      <div className="absolute top-5 left-5 z-10 flex items-center gap-1.5 bg-black/40 backdrop-blur-md rounded-full px-3 py-1.5">
-        {ModeIcon && <ModeIcon size={14} className="text-white/80" />}
-        <span className="text-[10px] text-white/80 font-semibold">{MODES[p.mode].name}</span>
+      {/* Mode badge + optional Founder chip */}
+      <div className="absolute top-5 left-5 z-10 flex items-center gap-2">
+        <div className="flex items-center gap-1.5 bg-black/40 backdrop-blur-md rounded-full px-3 py-1.5">
+          {ModeIcon && <ModeIcon size={14} className="text-white/80" />}
+          <span className="text-[10px] text-white/80 font-semibold">{MODES[p.mode].name}</span>
+        </div>
+        {/* Founder ☾ — hybrid invite reward (mig 025). Visible to other
+            users so 'arrived via invitation' becomes a social proof
+            signal on the swipe deck. */}
+        {p.is_founder && (
+          <div
+            className="flex items-center gap-1 rounded-full px-2.5 py-1.5 backdrop-blur-md"
+            style={{
+              background: "rgba(245,158,11,0.25)",
+              boxShadow: "0 0 12px rgba(245,158,11,0.45)",
+              border: "1px solid rgba(245,158,11,0.55)",
+            }}
+            title="Founder — Inscrit via invitation"
+            aria-label="Founder — inscrit via invitation"
+          >
+            <span className="text-[12px] leading-none" aria-hidden="true">☾</span>
+            <span className="text-[9px] text-white font-bold uppercase tracking-wider">Founder</span>
+          </div>
+        )}
       </div>
 
       {/* Smart Queue Badges - below mode badge */}

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -46,6 +46,8 @@ export interface MatchCandidate {
   lat: number;
   /** Longitude */
   lng: number;
+  /** True if the candidate has the 'founder' achievement (signed up via invite code) */
+  is_founder?: boolean;
 }
 
 export interface ScoreBreakdown {
@@ -313,11 +315,13 @@ export async function findMatches(
   // ----- Step 5: Batch-fetch candidate data -----
   const candidateIds = ageFiltered.map((p) => p.id);
 
-  // Fetch all active modes for candidates, karma totals, and review averages in parallel
-  const [candidateModesMap, karmaMap, reviewMap] = await Promise.all([
+  // Fetch all active modes for candidates, karma totals, review averages,
+  // and founder-badge holders in parallel.
+  const [candidateModesMap, karmaMap, reviewMap, founderSet] = await Promise.all([
     getActiveModesForUsers(candidateIds),
     getKarmaForUsers(candidateIds),
     getReviewAvgForUsers(candidateIds),
+    getFounderUserIds(candidateIds),
   ]);
 
   // ----- Step 6: Score each candidate -----
@@ -354,6 +358,10 @@ export async function findMatches(
       // rough value (see the "Positions floutées à ~500m" trust banner).
       lat: candidate.lat_rough,
       lng: candidate.lng_rough,
+      // 2026-04-26: hybrid invite reward — surface founder badge so
+      // SwipeCard can render the chip without re-querying achievements
+      // per card.
+      is_founder: founderSet.has(candidate.id),
     };
   });
 
@@ -447,6 +455,29 @@ async function getKarmaForUsers(
 }
 
 /** Batch-fetch average review rating for multiple users. */
+/**
+ * Returns the subset of `userIds` who hold the 'founder' achievement
+ * badge (i.e. signed up via an invite code, mig 025 hybrid reward).
+ * Single SELECT, no joins — much cheaper than per-card queries.
+ */
+async function getFounderUserIds(userIds: string[]): Promise<Set<string>> {
+  const set = new Set<string>();
+  if (userIds.length === 0) return set;
+
+  const { data, error } = await supabase
+    .from("achievements")
+    .select("user_id")
+    .eq("achievement_key", "founder")
+    .in("user_id", userIds);
+
+  if (error || !data) return set;
+
+  for (const row of data as Array<{ user_id: string }>) {
+    set.add(row.user_id);
+  }
+  return set;
+}
+
 async function getReviewAvgForUsers(
   userIds: string[],
 ): Promise<Map<string, number>> {

--- a/src/lib/mock-profiles.ts
+++ b/src/lib/mock-profiles.ts
@@ -20,6 +20,9 @@ export interface Profile {
   color: string;
   photo: string;
   photos?: string[];
+  /** Hybrid invite reward badge — set on the SwipeCard if the user signed
+   *  up via an invitation code (mig 025 / achievement_key='founder'). */
+  is_founder?: boolean;
   // Mode-specific
   cuisine?: string;
   event?: string;


### PR DESCRIPTION
Adds is_founder to MatchCandidate via a 4th batched query in matching.ts, propagates to Profile, and renders a gold-accent ☾ FOUNDER chip on SwipeCard when present. Zero N+1. tsc clean. Auto-merge OK.