### PR TITLE
feat(swipe): UX polish — photo bars + notif clearance + bigger action buttons (chantier 1/4)

### DIFF
--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -509,11 +509,11 @@ function ActionButtons({
           <motion.button
             onClick={onPass}
             aria-label="Passer"
-            className="w-[56px] h-[56px] rounded-full bg-bg border-2 border-border flex items-center justify-center text-text-muted"
+            className="w-[60px] h-[60px] rounded-full bg-bg-card border-[2px] border-border flex items-center justify-center text-text shadow-[0_4px_16px_-4px_rgba(0,0,0,0.18)]"
             whileTap={micro.tapScale}
-            whileHover={{ ...micro.hoverLift, borderColor: "color-mix(in srgb, var(--color-text) 40%, transparent)" }}
+            whileHover={{ ...micro.hoverLift, borderColor: "color-mix(in srgb, var(--color-text) 50%, transparent)" }}
           >
-            <IconX size={24} />
+            <IconX size={26} />
           </motion.button>
         </Magnetic>
 
@@ -560,15 +560,15 @@ function ActionButtons({
           <motion.button
             onClick={onLike}
             aria-label="Liker"
-            className="w-[56px] h-[56px] rounded-full gradient-bg flex items-center justify-center text-white shadow-glow"
+            className="w-[60px] h-[60px] rounded-full gradient-bg flex items-center justify-center text-white shadow-[0_8px_28px_-6px_color-mix(in_srgb,var(--color-accent-2)_60%,transparent)]"
             whileTap={micro.tapScale}
             whileHover={{
               y: -3,
-              boxShadow: "0 12px 40px color-mix(in srgb, var(--color-accent-2) 45%, transparent)",
+              boxShadow: "0 12px 40px color-mix(in srgb, var(--color-accent-2) 55%, transparent)",
               transition: springs.gentle,
             }}
           >
-            <IconHeart size={24} />
+            <IconHeart size={26} />
           </motion.button>
         </Magnetic>
       </div>

--- a/src/components/app/NotificationPreview.tsx
+++ b/src/components/app/NotificationPreview.tsx
@@ -52,8 +52,10 @@ export default function NotificationPreview() {
       aria-live="polite"
       aria-label="Notifications"
     >
-      {/* Desktop clamp: mirrors AppShell phone frame (max-w-[440px], centered). */}
-      <div className="mx-auto w-full md:max-w-[440px] px-4 pt-3">
+      {/* Desktop clamp: mirrors AppShell phone frame (max-w-[440px], centered).
+          pt-14 (56px) clears the page header so the notification banner stops
+          stepping on the brand mark on /browse, /feed, and other deep routes. */}
+      <div className="mx-auto w-full md:max-w-[440px] px-4 pt-14">
         <AnimatePresence mode="wait">
           {visible && (
             <m.div

--- a/src/components/app/PhotoGallery.tsx
+++ b/src/components/app/PhotoGallery.tsx
@@ -188,9 +188,11 @@ export default function PhotoGallery({
           </motion.div>
         </AnimatePresence>
 
-        {/* Dot indicators at bottom */}
+        {/* Photo position bars (Instagram/Tinder pattern) — top of card,
+            always visible. Replaces dots-at-bottom which were hidden by
+            the info panel. Each bar fills as the photo slot is "active". */}
         {total > 1 && (
-          <div className="absolute bottom-4 left-0 right-0 z-20 flex justify-center gap-1.5">
+          <div className="absolute top-2.5 left-3 right-3 z-20 flex gap-1">
             {Array.from({ length: total }).map((_, i) => (
               <button
                 key={i}
@@ -198,28 +200,18 @@ export default function PhotoGallery({
                   e.stopPropagation();
                   goTo(i);
                 }}
-                className="relative w-2 h-2 rounded-full"
+                className="relative h-[3px] flex-1 rounded-full overflow-hidden bg-white/25"
                 aria-label={`Photo ${i + 1}`}
                 aria-current={i === currentIndex ? "true" : undefined}
               >
-                <div
-                  className="w-full h-full rounded-full transition-all duration-200"
-                  style={{
-                    backgroundColor:
-                      i === currentIndex
-                        ? "rgba(255,255,255,0.95)"
-                        : "rgba(255,255,255,0.35)",
-                    transform: i === currentIndex ? "scale(1.3)" : "scale(1)",
+                <motion.div
+                  className="absolute inset-y-0 left-0 rounded-full bg-white/95"
+                  initial={false}
+                  animate={{
+                    width: i === currentIndex ? "100%" : i < currentIndex ? "100%" : "0%",
                   }}
+                  transition={{ duration: 0.25, ease: "easeOut" }}
                 />
-                {/* Smooth sliding indicator via layoutId */}
-                {i === currentIndex && (
-                  <motion.div
-                    layoutId="photo-dot-active"
-                    className="absolute inset-[-1px] rounded-full border border-white/60"
-                    transition={springs.snap}
-                  />
-                )}
               </button>
             ))}
           </div>


### PR DESCRIPTION
Photo carousel bars at top (visible), banner notif no longer covers header, action buttons bigger + contrasted. tsc clean. Auto-merge OK.