### PR TITLE
fix(visual): /browse buttons clipped + /map pin incrustation

### DIFF
--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -487,7 +487,12 @@ function ActionButtons({
   canAffordRose: boolean;
 }) {
   return (
-    <div className="shrink-0 pt-2 pb-[76px]" role="group" aria-label="Actions">
+    // 2026-04-26 fix: pb-[76px] left only 16px clearance over the BottomNav
+    // (h-[60px] + safe-area-inset-bottom on iPhone). Action buttons (60px tall)
+    // got clipped — heart/super-like visible only top-half on devices with a
+    // home bar. Bumped to 96px + safe-area so circles always sit fully above
+    // the glass nav. Pair with pt-2 for symmetric spacing above.
+    <div className="shrink-0 pt-2 pb-[calc(96px+env(safe-area-inset-bottom))]" role="group" aria-label="Actions">
       {/* Small undo icon above main row */}
       <div className="flex justify-center mb-2">
         <motion.button

--- a/src/app/(app)/map/page.tsx
+++ b/src/app/(app)/map/page.tsx
@@ -365,6 +365,10 @@ export default function MapPage() {
         const size = Math.min(64, 36 + count * 2);
         const el = document.createElement("div");
         el.className = "cesoir-cluster-pin";
+        // 2026-04-26 fix: same pre-positioning incrustation bug as
+        // ProfilePin — start invisible until MapLibre applies the marker
+        // transform. cesoir-cluster-burst keyframes already start at
+        // opacity:0; reduced-motion users get opacity:1 explicitly.
         el.style.cssText = `
           width: ${size}px; height: ${size}px; border-radius: 50%;
           background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
@@ -372,6 +376,7 @@ export default function MapPage() {
           display: flex; align-items: center; justify-content: center; cursor: pointer;
           box-shadow: 0 0 24px color-mix(in srgb, var(--color-accent) 40%, transparent);
           border: 2px solid white;
+          opacity: ${reduced ? "1" : "0"};
           ${reduced ? "" : `animation: cesoir-cluster-burst 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) ${Math.min(idx * 0.02, 0.4)}s both;`}
         `;
         el.textContent = `${count}`;

--- a/src/components/map/ProfilePin.tsx
+++ b/src/components/map/ProfilePin.tsx
@@ -86,6 +86,13 @@ export function ensurePinStyles(): void {
       width: 48px; height: 48px;
       cursor: pointer;
       will-change: transform, opacity, filter;
+      /* 2026-04-26 fix: start invisible. Without this, the pin paints once
+         at its initial DOM position (top-left of the map container) BEFORE
+         MapLibre applies the transform that moves it to the real lng/lat —
+         that's the "moon-shaped incrustation" QA caught at the search bar's
+         left edge on /map. The cesoir-pin-burst animation re-fades opacity
+         to 1 within 420ms; reduced-motion gets a hard opacity:1 below. */
+      opacity: 0;
       transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
                   opacity 200ms ease-out,
                   filter 200ms ease-out,
@@ -144,6 +151,9 @@ export function ensurePinStyles(): void {
         animation: none !important;
         transition-duration: 0ms !important;
       }
+      /* Without the burst animation, restore opacity so the pin is visible.
+         Pair with the opacity:0 default added above. */
+      .cesoir-pin-root { opacity: 1; }
       .cesoir-pin-ring.online,
       .cesoir-pin-ring.event { display: none; }
     }


### PR DESCRIPTION
## Summary

User reported 2 visual bugs while clicking through the app via screenshots.

## Bugs fixed

### 1. /browse — Action buttons cut by BottomNav
The 60×60 X / Heart / SuperLike circles were half-hidden behind the glass nav on iPhone. Hardcoded `pb-[76px]` (16px clearance) was insufficient when the nav adds `safe-area-inset-bottom` on devices with a home bar (~94px total). Bumped to `pb-[calc(96px+env(safe-area-inset-bottom))]`.

### 2. /map — Round badge "incrustation" in search bar
A violet/cyan circular badge briefly appeared in the top-left of the search bar. Root cause: MapLibre custom-element markers are appended to the DOM BEFORE the per-pin transform is applied — there's a single paint frame where every pin sits at (0, 0) of the map container. Pins then jump to their real lng/lat on the next frame.

Fix: `.cesoir-pin-root` and `.cesoir-cluster-pin` start at `opacity: 0`. The existing `cesoir-pin-burst` keyframes already animate opacity 0→1 over 420ms, which masks the position jump. Reduced-motion users get an explicit `opacity: 1` so they still see pins.

## Verification

- [x] /browse 390×844 viewport: action buttons render fully above nav
- [x] /map: 0 pre-positioned pins at (0, 0); search bar clean
- [x] `npx tsc --noEmit` passes
- [x] Visual confirmation via Playwright screenshot before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)