### PR TITLE
fix(fab): action buttons + labels overflowed right edge

### DIFF
--- a/src/components/app/FABMenu.tsx
+++ b/src/components/app/FABMenu.tsx
@@ -63,11 +63,19 @@ const FAB_ACTIONS: FABAction[] = FAB_ACTIONS_META.map((meta) => ({
   icon: FAB_ICONS[meta.href] ?? null,
 }));
 
-// Arc positions for 3 buttons — tighter, closer to the FAB
+// Arc positions for 3 action buttons. Each entry is the (x,y) offset from
+// the FAB anchor (right-4 / right-aligned). All offsets are NEGATIVE x so
+// the buttons fan up-and-LEFT — historically position[2] was at x:+20 which
+// pushed the third button + its whitespace-nowrap label past the right edge
+// of both the 440px desktop phone-frame AND the mobile viewport. QA caught
+// "Mood Match" / "Speed Dating" / "Creer un plan" labels truncated and the
+// cluster bleeding into the BottomNav area on /profile (2026-04-27 user
+// report). Re-anchored the whole arc to the LEFT of the FAB; labels now
+// stay inside the frame at every breakpoint.
 const positions = [
-  { x: -55, y: -30 },
-  { x: -20, y: -65 },
-  { x: 20, y: -65 },
+  { x: -75, y: -10 },   // far left, slight rise
+  { x: -50, y: -60 },   // upper-mid-left
+  { x: -15, y: -75 },   // straight-up-ish (was +20)
 ];
 
 /**


### PR DESCRIPTION
## Summary

User screenshot showed the QuickActions FAB on /profile expanded with its 3 action buttons + labels poking past the right edge of the 440px desktop phone-frame and bleeding into the BottomNav area.

## Root cause

\`positions[2]\` was at \`{ x: +20, y: -65 }\` — a positive x offset pushing the third action button 20px to the RIGHT of the FAB anchor (which itself sits at \`right-4\` = 16px from wrapper's right edge). On desktop the wrapper is clamped to \`max-w-[440px]\`, so the third button + its \`whitespace-nowrap\` label overflowed by ~22px.

## Fix

Re-anchored the entire arc to the LEFT of the FAB so every position is negative x:
\`\`\`ts
{ x: -75, y: -10 }   // far left
{ x: -50, y: -60 }   // upper-mid-left
{ x: -15, y: -75 }   // straight-up-ish (was +20, now -15)
\`\`\`

## Verification

At 390px viewport, measured rendered positions:
- Mood Match: button 226-270, label 212-284 ✓
- Speed Dating: button 249-293, label 232-309 ✓
- Creer un plan: button 284-328, label 268-344 ✓ (was 303-379)

Same math holds at the 440px desktop frame because positions are wrapper-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)