### PR TITLE
fix(audit-r4): 10 parallel agents — P1 visual + UX + Wave 16 prep

### DIFF
--- a/audit/round4/WAVE-16-GAMIFICATION-FRONTEND.md
+++ b/audit/round4/WAVE-16-GAMIFICATION-FRONTEND.md
@@ -1,0 +1,328 @@
+# Wave 16 — Bet #5: Gamification Frontend Surfacing
+
+> **Status:** Spec ready for engineer pickup.
+> **Owner:** TBD.
+> **Estimated effort:** ~10h end-to-end.
+> **Goal:** surface XP / level / badge progression in 3 high-traffic locations to drive retention. Backend (`useGamification`, `useBadges`, achievements + karma_transactions tables, realtime updates) is already production-ready — this is **pure frontend visibility work**.
+
+---
+
+## 1. Current State Inventory
+
+### What EXISTS (and works)
+
+| File | Status | Notes |
+|------|--------|-------|
+| `src/lib/gamification.ts` | Production | 20-level table, 8 XP actions, `calculateLevel()`, `checkLevelUp()`, level rewards |
+| `src/lib/useGamification.ts` | Production | Realtime XP updates via `karma_transactions` channel, `addXP()` helper, `showLevelUp` state, `xpPopups` queue |
+| `src/lib/badges.ts` | Production | 30 badges, 6 categories, 4 rarity tiers with color config |
+| `src/lib/useBadges.ts` | Production | Reads `achievements` table, computes progress per badge from `conversations`/`messages`/`invite_codes`/`profiles`, `checkAndAward()` writes new earnings + emits karma_transactions |
+| `src/app/(app)/progress/page.tsx` | Production | 5 tabs (Badges / Defis / Classement / Confiance / Reviews) showing earned + in-progress badges with rarity glow |
+| `src/components/moments/LevelUpCounter.tsx` | Exists (verify usage) | Counter primitive, may already be plugged into some page |
+| `src/components/ui/Toast.tsx` | Production | Has `match` variant with gradient. Provider mounted in root layout. Use `useToast()` hook. |
+| `src/components/app/MatchCinematic.tsx` | Production | Full-screen takeover, 16-particle confetti, overshoot avatar spring, 8s auto-dismiss with pause-on-hover, sound + haptics. **Use as the cinematic-template for badge unlock.** |
+
+### What is MISSING in UI
+
+| Surface | Visibility | Issue |
+|---------|------------|-------|
+| **XP bar** | Nowhere | The user's XP / level / progress to next level is invisible across the entire app. Only viewable inside `/progress > Confiance` tab — 3 taps deep. |
+| **Level-up notification** | Nowhere | `useGamification.showLevelUp` state is set when XP crosses a threshold but NO COMPONENT renders it. The state is dead. Confetti exists in MatchCinematic but isn't reused. |
+| **Badge unlock animation** | Nowhere | `useBadges.checkAndAward()` returns newly earned badge IDs but no caller fires a celebration. Users earn badges in silence — they only discover later by visiting `/progress > Badges`. |
+| **XP popup on action** | Partially | `useGamification.xpPopups` queue exists (e.g. "+50 XP - Profil complet"). Need to render it. Likely a small floating "+50 XP" pill near the top-right. |
+
+### Root cause
+The progression backend was built first (the data is correct, realtime works, level math is solid). The visibility layer was scoped for "later" — now is later.
+
+---
+
+## 2. Three Surfacing Locations (in order of impact)
+
+### A) XP Bar in PageHeader (always visible)
+
+**Why first:** users see PageHeader on every authenticated screen. Adding the XP bar makes progression a constant ambient signal — the same trick Duolingo / Strava / fitness trackers use to keep engagement high.
+
+**Visual spec:**
+- Renders BELOW the title row, ABOVE the hairline (use `slotBelowTitle` slot — already supported)
+- ~24px tall total: small "L7" pill on the left + thin progress bar + "1 240 / 1 700 XP" label on the right
+- Bar fills with `gradient-bg` (existing `linear-gradient(violet → green-fluo)`)
+- On hover/tap: tooltip "Encore 460 XP avant le niveau Influent" (uses next-level title from `LEVELS` table)
+- On level-up: brief glow pulse animation on the bar (1.5s)
+- **Reduced motion:** static bar, no glow
+
+**A11y:** `role="progressbar"`, `aria-valuemin=0`, `aria-valuemax={nextLevelXP}`, `aria-valuenow={currentXP}`, `aria-label="Progression niveau {level} {title}"`.
+
+**Density toggle:** in compact mode (e.g. `/chat/[id]`, `/browse`), the bar is hidden by default. Caller can opt-in via a new `showXPBar` prop on `PageHeader` (defaults to `true`). Pages that need vertical real estate (chat view) opt out.
+
+### B) Level-Up Toast (cinematic, when XP crosses threshold)
+
+**Why second:** level-ups are the single biggest dopamine moment in the system — they MUST feel earned. Today they happen invisibly.
+
+**Visual spec:**
+- NOT the existing toast (too small). Use a centered-modal pattern, 4-5 second auto-dismiss
+- Component: `src/components/gamification/LevelUpModal.tsx` (new)
+- Animation:
+  - Backdrop fades in (300ms)
+  - Number `7` (the new level) zooms 0.4 → 1.1 → 1.0 with spring overshoot (700ms)
+  - Confetti burst (reuse the 16-particle pattern from `MatchCinematic.tsx:194-226` exactly — colors `#8B5CF6, #00FF88, #EC4899, #FACC15, #06B6D4`)
+  - Title "Niveau 7 - Populaire" rises with `y: 20 -> 0`, `opacity: 0 -> 1`
+  - Reward chips appear staggered: "🔥 Badge Populaire", "⚡ Boost x2 24h"
+  - "Continuer" button at bottom, single CTA
+- Uses existing `LevelUpData.rewards` array from `useGamification.showLevelUp`
+- Sound + haptic on open: reuse `playSound("match")` and `haptics.match()` (or add a new `playSound("levelup")` — sample search shows `src/lib/sounds.ts`)
+
+**Trigger:**
+- Mount once in root authenticated layout (`src/app/(app)/layout.tsx`)
+- Subscribe to `useGamification().showLevelUp` — when truthy, render `<LevelUpModal />`
+- On dismiss → call `dismissLevelUp()`
+- Already-built `useGamification` realtime listener on `karma_transactions` triggers level-up detection
+
+**A11y:** `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at the level number, ESC closes.
+
+### C) Badge Unlock Animation (mini-cinematic, 4s)
+
+**Why third:** badges are smaller dopamine hits than levels but happen 30x more often (30 badges total). They deserve recognition without dominating the screen.
+
+**Visual spec:**
+- Component: `src/components/gamification/BadgeUnlockCinematic.tsx` (new)
+- 60-70% scale of `MatchCinematic` — NOT full screen, more like a card overlay
+- Rendered in a portal at the center of the viewport
+- Animation (4-second total):
+  - Backdrop fades in 300ms (lower opacity than match cinematic — 0.6 not 0.85)
+  - Badge emoji scales 0.3 → 1.2 → 1.0 with overshoot (700ms)
+  - Glow ring uses the badge's `RARITY_CONFIG.glowColor` (existing config)
+  - 8 confetti particles (half of MatchCinematic's 16 — keep it punchier, less ceremonial)
+  - Badge name appears below: "Badge debloque - {name}"
+  - "+{xp} XP" pill fades in
+  - "Voir tous les badges" link at bottom (small, secondary)
+- Auto-dismiss after 4s; tap-anywhere or ESC dismisses early
+- **Queueing:** if multiple badges are awarded in one tick, show them sequentially (1.5s gap between)
+
+**Trigger:**
+- Listen to `useBadges` for new awards. Two integration points:
+  1. **After explicit `checkAndAward()` call** (e.g. on match accept, message send, profile completion) — the caller already knows what to do
+  2. **Realtime achievements channel** — subscribe to `achievements` table INSERTs filtered to current user (similar pattern to `useGamification`'s xp channel)
+
+**Implementation tip:** add a `BadgeUnlockProvider` (context) with a queue, push to it from `useBadges.checkAndAward` callback, render the modal at root layout level. Same pattern as `useToast`.
+
+---
+
+## 3. Implementation per Location
+
+### A) XP Bar in PageHeader
+
+**Files to edit/create:**
+- NEW: `src/components/gamification/XPBar.tsx`
+- EDIT: `src/components/ui/PageHeader.tsx` — add `showXPBar?: boolean` prop (default `true`), render `<XPBar />` inside `slotBelowTitle` if no slot is already provided
+- EDIT: pages that opt-out (e.g. `src/app/(app)/chat/[id]/page.tsx`) — pass `showXPBar={false}`
+
+**State management:**
+```tsx
+// XPBar.tsx
+"use client";
+import Link from "next/link";
+import { m } from "motion/react";
+import { useGamification } from "@/lib/useGamification";
+import { LEVELS } from "@/lib/gamification";
+
+export function XPBar() {
+  const { level, title, currentXP, nextLevelXP, progress, loading } = useGamification();
+
+  if (loading) return <div className="h-6" aria-hidden="true" />;
+  if (level >= LEVELS.length) return <MaxLevelBadge />;  // separate cosmetic for max level
+
+  const nextTitle = LEVELS[level]?.title ?? title;
+
+  return (
+    <Link
+      href="/progress"
+      className="block group"
+      aria-label={`Niveau ${level} ${title}, ${currentXP} sur ${nextLevelXP} XP`}
+    >
+      <div className="flex items-center gap-2 px-4 py-1.5">
+        <span className="text-[10px] font-black px-1.5 py-0.5 rounded-full gradient-bg text-white shrink-0">
+          L{level}
+        </span>
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={nextLevelXP}
+          aria-valuenow={currentXP}
+          className="flex-1 h-1.5 rounded-full bg-border/50 overflow-hidden"
+        >
+          <m.div
+            className="h-full gradient-bg"
+            initial={{ width: 0 }}
+            animate={{ width: `${Math.round(progress * 100)}%` }}
+            transition={{ duration: 0.8, ease: "easeOut" }}
+          />
+        </div>
+        <span className="text-[10px] text-text-muted shrink-0 group-hover:text-text transition-colors">
+          {currentXP}/{nextLevelXP}
+        </span>
+      </div>
+    </Link>
+  );
+}
+```
+
+**Realtime:** automatic via `useGamification`'s existing `karma_transactions` channel — bar will animate as XP arrives.
+
+**Cohesion link:** the entire bar is a `<Link href="/progress">` — direct entry to the progression hub.
+
+### B) Level-Up Modal
+
+**Files to create:**
+- NEW: `src/components/gamification/LevelUpModal.tsx` (~150 lines, pattern adapted from `MatchCinematic.tsx`)
+- EDIT: `src/app/(app)/layout.tsx` — mount `<LevelUpListener />` once at the top, near the existing providers
+
+**Listener pattern:**
+```tsx
+// LevelUpListener.tsx — invisible component that wires the modal
+"use client";
+import { useGamification } from "@/lib/useGamification";
+import { LevelUpModal } from "./LevelUpModal";
+
+export function LevelUpListener() {
+  const { showLevelUp, dismissLevelUp } = useGamification();
+  return <LevelUpModal data={showLevelUp} onDismiss={dismissLevelUp} />;
+}
+```
+
+**Animation patterns to reuse:**
+- `springs.elastic`, `easings.overshoot` from `@/lib/motion-design`
+- Confetti loop pattern from `MatchCinematic.tsx:195-226` (verbatim)
+- `moodMatchVariants.matchCard` for the level number `<m.h2>` (rubber spring with rotateZ — already production)
+- `playSound("match")` and `haptics.match()` (or add `levelup` variants if user prefers)
+
+**A11y:**
+- Focus trap on open (use existing pattern from MatchCinematic — listens for ESC)
+- Live region announces "Niveau {n} - {title} debloque"
+- All confetti / glow has `aria-hidden="true"`
+- `prefers-reduced-motion`: skip confetti + scale animations, just fade in the static card
+
+**Cohesion link:** rewards block has "Voir mes niveaux" → `/progress?tab=trust` (the Confiance tab shows level breakdown).
+
+### C) Badge Unlock Cinematic
+
+**Files to create/edit:**
+- NEW: `src/components/gamification/BadgeUnlockCinematic.tsx` (~120 lines)
+- NEW: `src/components/gamification/BadgeUnlockProvider.tsx` (queue context)
+- EDIT: `src/app/(app)/layout.tsx` — wrap children in `<BadgeUnlockProvider>`
+- EDIT: `src/lib/useBadges.ts` — after `checkAndAward()` writes new achievements (around line 490), call `pushBadgeUnlock(badge)` from the new context for each newly earned id
+
+**Provider pattern:**
+```tsx
+// BadgeUnlockProvider.tsx
+"use client";
+import { createContext, useContext, useState, useCallback } from "react";
+import type { Badge } from "@/lib/badges";
+import { BadgeUnlockCinematic } from "./BadgeUnlockCinematic";
+
+interface Ctx {
+  pushBadgeUnlock: (b: Badge) => void;
+}
+const BadgeCtx = createContext<Ctx | null>(null);
+export const useBadgeUnlock = () => {
+  const c = useContext(BadgeCtx);
+  if (!c) throw new Error("useBadgeUnlock outside provider");
+  return c;
+};
+
+export function BadgeUnlockProvider({ children }: { children: React.ReactNode }) {
+  const [queue, setQueue] = useState<Badge[]>([]);
+  const pushBadgeUnlock = useCallback((b: Badge) => {
+    setQueue((q) => [...q, b]);
+  }, []);
+  const dismiss = useCallback(() => {
+    setQueue((q) => q.slice(1));
+  }, []);
+
+  return (
+    <BadgeCtx.Provider value={{ pushBadgeUnlock }}>
+      {children}
+      {queue[0] && <BadgeUnlockCinematic badge={queue[0]} onDismiss={dismiss} />}
+    </BadgeCtx.Provider>
+  );
+}
+```
+
+**useBadges integration** (around line 490 of `src/lib/useBadges.ts`):
+```ts
+// After successful insert into achievements:
+const newlyEarned: string[] = [];
+for (const bp of all) {
+  if (bp.earned && !earnedIds.has(bp.badge.id)) {
+    const { error } = await supabase.from("achievements").insert({...});
+    if (!error) {
+      newlyEarned.push(bp.badge.id);
+      pushBadgeUnlock(bp.badge);  // <-- NEW: trigger cinematic
+      await supabase.from("karma_transactions").insert({...});
+    }
+  }
+}
+```
+
+**Realtime fallback:** also subscribe to `achievements` INSERTs in `useBadges` so badges earned by SERVER-side triggers (e.g. invite-rewards-hybrid migration 025 might award `ambassadeur` server-side) also fire the cinematic. Same pattern as `useGamification`'s realtime channel.
+
+**A11y:**
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby={badge-name-id}`
+- Live region with badge name + XP gained
+- ESC closes, tap backdrop closes, auto-dismiss after 4s
+- `prefers-reduced-motion`: replace cinematic with a single subtle toast using existing `useToast` ("Badge debloque: {name} +{xp} XP")
+
+**Cohesion link:** "Voir tous les badges" CTA at bottom of cinematic → `/progress` (defaults to Badges tab — already the first tab).
+
+---
+
+## 4. Cohesion with Existing /progress page
+
+All three surfacings link back to `/progress`:
+- **XP Bar** (always-visible) wraps the whole bar in `<Link href="/progress">` — single tap to dive in
+- **Level-Up Modal** has secondary CTA "Voir mes niveaux" → `/progress?tab=trust` (the Confiance tab shows level/XP breakdown)
+- **Badge Cinematic** has bottom link "Voir tous les badges" → `/progress` (Badges is the default tab)
+
+This makes `/progress` the cathedral and the three surfacings the doorbells. Today the page has no inbound traffic from anywhere except the bottom-nav profile route. Post-Wave-16 it should be the most-visited page after `/browse` and `/chat`.
+
+**One edit on `/progress`:** add a small banner on first visit AFTER level-up that congratulates the user and invites a share — e.g. "Tu viens de passer niveau 7 ! Partage avec un ami." — using the existing `referral.ts` link generator. Wire via `?levelup=7` query param set by the LevelUpModal CTA.
+
+---
+
+## 5. Estimated Effort + Sequencing
+
+| Step | Description | Hours |
+|------|-------------|-------|
+| A1 | Create `XPBar.tsx` (component + a11y + animation) | 1.5 |
+| A2 | Wire into `PageHeader.tsx` with opt-out prop, audit which pages opt-out | 1.0 |
+| A3 | Test loading state, max level, reduced motion | 0.5 |
+| B1 | Create `LevelUpModal.tsx` (adapt from MatchCinematic, ~150 lines) | 2.0 |
+| B2 | Create `LevelUpListener.tsx`, mount in `(app)/layout.tsx` | 0.3 |
+| B3 | Add `playSound("levelup")` if not present, copy haptic call | 0.3 |
+| B4 | Test with manual XP injection (devtools), reduced-motion variant | 0.5 |
+| C1 | Create `BadgeUnlockProvider.tsx` queue + context | 0.5 |
+| C2 | Create `BadgeUnlockCinematic.tsx` (~120 lines) | 2.0 |
+| C3 | Wire `useBadges.checkAndAward` to `pushBadgeUnlock` | 0.3 |
+| C4 | Add `achievements` realtime channel to `useBadges` | 0.5 |
+| C5 | Test queueing of multiple simultaneous badges, a11y, reduced-motion fallback toast | 0.5 |
+| - | `/progress` post-levelup banner via query param | 0.5 |
+| - | PostHog events: `xpbar_clicked`, `levelup_shown`, `levelup_dismissed`, `badge_unlock_shown` | 0.3 |
+| - | Buffer | 0.3 |
+| **Total** | | **~10 hours** |
+
+### Recommended sequencing
+1. **Ship A first (XP Bar)** — fastest visible win, low risk, 3 hours. Get it in front of users on day 1, gather telemetry on `xpbar_clicked` to validate /progress traffic uplift.
+2. **Then C (Badge Cinematic)** — frequent trigger (30 badges, more surfaces firing), tests the cinematic pattern at scale before B's bigger moment. ~3.5h.
+3. **Finally B (Level-Up Modal)** — rare event (level changes maybe weekly per user), but highest emotional weight. Polish hardest. ~3h.
+
+Total wall-clock: 1.5 days for one engineer. Can be split — A is independent, B and C can be parallelized if two engineers.
+
+---
+
+## 6. Out of Scope (followups)
+
+- **Streak counter** in PageHeader (next to L7 pill) — useChallenges already has streak data, but the visual + reward loop needs design work
+- **Animated XP pop on action** ("+50 XP" pill that floats from interaction point) — use `useGamification.xpPopups` queue, similar to badge cinematic but smaller. P1.
+- **Compare with friends** widget — show how many badges your matches have earned. Needs friends graph (currently not really modeled — only `invite_codes`).
+- **Share level-up to social** — "I just hit level 7 on CeSoir!" share card with og:image. Needs OG image generator route.
+- **Sound design pass** — currently reuses `match` sound. A dedicated `levelup.mp3` (longer, more triumphant) and `badge.mp3` (shorter, lighter) would distinguish the moments.
+- **Progress prediction** — "5 days at this pace = level 8". Needs trailing-7d XP velocity calc.

--- a/audit/round4/WAVE-16-PUSH-NOTIFS.md
+++ b/audit/round4/WAVE-16-PUSH-NOTIFS.md
@@ -1,0 +1,609 @@
+# Wave 16 — Bet #4: Web Push Notifications (match + message)
+
+> **Status:** Spec ready for engineer pickup.
+> **Owner:** TBD.
+> **Estimated effort:** ~14h end-to-end (P0 unblock for PWA installability).
+> **Goal:** deliver real push notifications for two events — `new_match` and `new_message` — to logged-in users on Android Chrome / desktop / iOS 16.4+ (PWA installed).
+
+---
+
+## 1. Architecture (text diagram)
+
+```
+[Browser - logged-in user]                           [Supabase Postgres]
+       |                                                     |
+       |  1. Settings page toggle "Notifications push"       |
+       |  -> usePushNotifications.subscribe()                |
+       |     - Notification.requestPermission()              |
+       |     - registration.pushManager.subscribe(VAPID_PUB) |
+       |                                                     |
+       |  2. POST /api/push/subscribe                        |
+       |  ----------------------------------------> [Next.js API route]
+       |                                              - upsert row in
+       |                                                push_subscriptions
+       |                                              - returns 201
+       |                                                     |
+       |                                              [Supabase realtime trigger]
+       |                                              ON INSERT INTO conversations
+       |                                              ON INSERT INTO messages
+       |                                              -> calls Edge Function
+       |                                                     |
+       |                                              [Supabase Edge Function:
+       |                                               send-push]
+       |                                              - reads push_subscriptions
+       |                                                for recipient_id
+       |                                              - signs payload with
+       |                                                VAPID_PRIVATE_KEY (web-push)
+       |                                              - POSTs to FCM/Apple/Mozilla
+       |                                                push endpoint
+       |                                                     |
+[Service Worker]  <----------- push event payload ----------+
+       |
+       | self.addEventListener('push', ...)
+       |  -> showNotification(title, options)
+       |
+       | self.addEventListener('notificationclick', ...)
+       |  -> openWindow(targetUrl)
+[User taps notification] -> CeSoir tab focused / opened on chat or profile
+```
+
+Two layers do the work:
+1. **Subscribe layer** (already 70% built, just missing env + endpoint)
+2. **Send layer** (entirely missing — needs Edge Function + DB trigger)
+
+---
+
+## 2. Existing Infrastructure Inventory
+
+### Service Worker — `public/sw.js`
+**Status:** Push handler already implemented (lines 152-236). Ready to use as-is.
+- `push` event handler reads JSON payload, supports per-tag actions (`cesoir-match`, `cesoir-message`, `cesoir-plan`)
+- `notificationclick` handler focuses existing tab and navigates, or opens new window
+- Action buttons wired: "Voir le profil" / "Envoyer un message" for matches, "Repondre" for messages
+- Vibration pattern set: `[100, 50, 100]`
+- Bypass list correctly excludes `supabase.co` URLs from caching (PII boundary)
+
+**No changes required to sw.js.** The handler will work the moment a push arrives.
+
+### Push subscription hook — `src/lib/usePushNotifications.ts`
+**Status:** Built but DEAD due to missing env vars.
+- Reads `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (line 28) — currently empty string in production
+- Reads `NEXT_PUBLIC_PUSH_SUBSCRIPTION_URL` (line 54) — currently undefined, falls back to `logger.warn("push_subscription_url_missing")` and returns silently
+- `subscribe()` flow is correct: requests permission → ensures SW → calls `pushManager.subscribe()` → POSTs subscription to backend
+- `unsubscribe()` flow is correct: DELETE on backend + `subscription.unsubscribe()` locally
+
+**Required:** wire env vars + create the backend endpoint. No hook code changes.
+
+### Database — `push_subscriptions` table
+**Status:** Referenced in cleanup code but the migration creating it does NOT exist.
+- `src/app/api/account/delete/route.ts:105` lists `push_subscriptions` for cascade deletion on account deletion (so the cleanup story is already designed)
+- No migration file in `supabase/migrations/` creates this table
+- The audit/round3/pwa.md report (gap #5) confirms this is a P0 blocker
+
+**Action:** create migration `029_push_subscriptions.sql` (see step 4).
+
+### Edge Functions
+**Status:** None exist. `supabase/functions/` directory does not exist in repo.
+- The project uses Next.js API routes (`src/app/api/**`) for most server-side work, NOT Supabase Edge Functions
+- Recommendation: keep convention. Use a Next.js API route + a Postgres trigger that calls the route via `pg_net.http_post()` (Supabase has the extension enabled by default).
+- Alternative: Supabase Edge Function. Adds a new infra surface but is the standard pattern. For this spec we use the **Next.js API route** approach to match existing conventions.
+
+### Dependencies — `package.json`
+**Status:** `web-push` library is NOT installed. Required.
+- `npm install web-push` (server-side signing of push payloads with VAPID private key)
+- `npm install -D @types/web-push` (TypeScript types)
+
+### Existing notifications-related UI
+- `src/app/(app)/profile/notifications/page.tsx` — toggle UI for in-app notification preferences (matches/messages/likes/...). **This is per-event opt-in, NOT the master push permission switch.** The push opt-in needs a separate row at the top: "Activer les notifications push" → calls `subscribe()`/`unsubscribe()` from the hook.
+- `src/lib/useLiveNotifications.ts` — drives in-app notification banner from realtime queries. Unrelated to push, but useful pattern reference.
+- `src/components/app/MatchCinematic.tsx` — full-screen takeover when a match happens IN-APP. Push is only for when the app is **closed** or **backgrounded**. Both layers must coexist.
+
+---
+
+## 3. Implementation Steps (in order)
+
+### Step 1 — Generate VAPID keys (engineer task, 5 min)
+**Do not run from inside Claude.** Engineer runs locally:
+```bash
+npx web-push generate-vapid-keys
+```
+Output:
+```
+Public Key: BFx... (87 chars, base64url)
+Private Key: jZ8... (43 chars, base64url)
+```
+**Store immediately** in 1Password / Vercel encrypted env. Never commit either key to git.
+
+### Step 2 — Add env vars (10 min)
+**Files:**
+- `.env.sample` — add placeholders + documentation:
+  ```
+  # Push notifications (Wave 16 - Bet #4)
+  # Generate via: npx web-push generate-vapid-keys
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+  VAPID_PRIVATE_KEY=
+  VAPID_SUBJECT=mailto:contact@cesoir.app
+  NEXT_PUBLIC_PUSH_SUBSCRIPTION_URL=/api/push/subscribe
+  ```
+- **Vercel dashboard** — add the same 4 vars to Production + Preview + Development scopes. `VAPID_PRIVATE_KEY` and `VAPID_SUBJECT` must NOT have the `NEXT_PUBLIC_` prefix (server-only).
+
+### Step 3 — Create the push_subscriptions migration (30 min)
+**File:** `supabase/migrations/029_push_subscriptions.sql` (new)
+```sql
+-- Wave 16 Bet #4 — push_subscriptions table for web push delivery.
+-- One row per (user_id, endpoint). Endpoint is the unique key from
+-- pushManager.subscribe() and is what web-push needs to send a notification.
+
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  endpoint TEXT NOT NULL,
+  p256dh TEXT NOT NULL,           -- public key from subscription.toJSON().keys.p256dh
+  auth TEXT NOT NULL,             -- auth secret from subscription.toJSON().keys.auth
+  user_agent TEXT,                -- diagnostic only
+  created_at TIMESTAMPTZ DEFAULT now(),
+  last_used_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(user_id, endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user
+  ON push_subscriptions (user_id);
+
+-- RLS: a user can only see / delete their own subscriptions.
+-- Inserts go through the service-role key from the API route.
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_read_own_subscriptions"
+  ON push_subscriptions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "users_delete_own_subscriptions"
+  ON push_subscriptions FOR DELETE
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE push_subscriptions IS
+  'Web push subscription endpoints. One row per device.
+   Used by /api/push/subscribe (write) and the send-push trigger (read with service role).';
+```
+Apply via `supabase db push` or `mcp__supabase__apply_migration`.
+
+### Step 4 — API route to save/delete subscriptions (1.5h)
+**File:** `src/app/api/push/subscribe/route.ts` (new)
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+// Uses the SERVICE ROLE key — bypasses RLS for the write because the row
+// must be insertable from the server even though the user can only read
+// their own rows via RLS.
+function adminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const { subscription } = await req.json();
+  if (!subscription?.endpoint || !subscription?.keys?.p256dh || !subscription?.keys?.auth) {
+    return NextResponse.json({ error: "invalid_subscription" }, { status: 400 });
+  }
+
+  // Auth: read the user from the Supabase session cookie.
+  // (The hook should attach the user's JWT in Authorization header — adapt
+  // to whichever pattern the rest of /api/* uses; check src/lib/supabase.ts
+  // for the SSR client helper.)
+  const supabase = adminClient();
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const { data: { user } } = await supabase.auth.getUser(authHeader.slice(7));
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase.from("push_subscriptions").upsert({
+    user_id: user.id,
+    endpoint: subscription.endpoint,
+    p256dh: subscription.keys.p256dh,
+    auth: subscription.keys.auth,
+    user_agent: req.headers.get("user-agent") ?? null,
+    last_used_at: new Date().toISOString(),
+  }, { onConflict: "user_id,endpoint" });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true }, { status: 201 });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { endpoint } = await req.json();
+  if (!endpoint) return NextResponse.json({ error: "missing_endpoint" }, { status: 400 });
+
+  const supabase = adminClient();
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const { data: { user } } = await supabase.auth.getUser(authHeader.slice(7));
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  await supabase.from("push_subscriptions")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("endpoint", endpoint);
+  return NextResponse.json({ ok: true });
+}
+```
+**Tweak `usePushNotifications.ts`** to forward the user's JWT in `sendSubscriptionToServer` / `removeSubscriptionFromServer` so the API can authenticate. Get the token from `supabase.auth.getSession()`.
+
+### Step 5 — API route to send a push (2h)
+**File:** `src/app/api/push/send/route.ts` (new)
+
+This is called server-side only (from a Postgres trigger via `pg_net.http_post`, NOT directly from the browser). Validates a shared secret header to prevent abuse.
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import webpush from "web-push";
+import { createClient } from "@supabase/supabase-js";
+
+webpush.setVapidDetails(
+  process.env.VAPID_SUBJECT!,
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!,
+);
+
+export async function POST(req: NextRequest) {
+  // Shared secret check — only Postgres triggers should call this.
+  const secret = req.headers.get("x-internal-secret");
+  if (secret !== process.env.PUSH_INTERNAL_SECRET) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const { user_id, payload } = await req.json();
+  // payload shape: { title, body, tag, url, chatUrl?, profileUrl? }
+  // tag drives the SW action buttons: 'cesoir-match' | 'cesoir-message'
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: subs } = await supabase
+    .from("push_subscriptions")
+    .select("endpoint, p256dh, auth")
+    .eq("user_id", user_id);
+
+  if (!subs || subs.length === 0) {
+    return NextResponse.json({ ok: true, delivered: 0 });
+  }
+
+  const stalEndpoints: string[] = [];
+  const results = await Promise.allSettled(subs.map(async (s) => {
+    try {
+      await webpush.sendNotification(
+        { endpoint: s.endpoint, keys: { p256dh: s.p256dh, auth: s.auth } },
+        JSON.stringify(payload),
+      );
+    } catch (err: any) {
+      // 404 / 410 = endpoint expired -> delete from DB
+      if (err.statusCode === 404 || err.statusCode === 410) {
+        stalEndpoints.push(s.endpoint);
+      }
+      throw err;
+    }
+  }));
+
+  if (stalEndpoints.length > 0) {
+    await supabase.from("push_subscriptions")
+      .delete()
+      .in("endpoint", stalEndpoints);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    delivered: results.filter(r => r.status === "fulfilled").length,
+    failed: results.filter(r => r.status === "rejected").length,
+  });
+}
+```
+
+**Add env var:** `PUSH_INTERNAL_SECRET=<random 32 chars>` to Vercel + .env.sample.
+
+### Step 6 — Postgres triggers for the two events (2h)
+**File:** `supabase/migrations/030_push_triggers.sql` (new)
+```sql
+-- Wave 16 Bet #4 — Postgres triggers that fire pushes on new match / new message.
+-- Uses pg_net (already enabled via 002_new_features.sql).
+
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Helper to call /api/push/send with the project URL.
+-- The URL must be set as a Postgres setting once at deploy time:
+--   ALTER DATABASE postgres SET app.push_send_url TO 'https://cesoir.app/api/push/send';
+--   ALTER DATABASE postgres SET app.push_internal_secret TO '<value>';
+-- (Or hardcode for now — the engineer can decide.)
+
+CREATE OR REPLACE FUNCTION send_push_notification(
+  p_user_id UUID,
+  p_payload JSONB
+) RETURNS VOID AS $$
+DECLARE
+  send_url TEXT := current_setting('app.push_send_url', true);
+  secret   TEXT := current_setting('app.push_internal_secret', true);
+BEGIN
+  IF send_url IS NULL OR secret IS NULL THEN
+    RAISE NOTICE 'push send skipped — settings missing';
+    RETURN;
+  END IF;
+  PERFORM net.http_post(
+    url := send_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-internal-secret', secret
+    ),
+    body := jsonb_build_object('user_id', p_user_id, 'payload', p_payload)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ─────────────────────────────────────────
+-- Trigger 1: new mutual match
+-- Fires when conversations row is inserted (existing schema uses `conversations`
+-- for matches — see useBadges.ts comment around line 336).
+-- Reads recipient name from profiles for the body.
+-- ─────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION on_new_match_send_push() RETURNS TRIGGER AS $$
+DECLARE
+  user_a_name TEXT;
+  user_b_name TEXT;
+BEGIN
+  SELECT name INTO user_a_name FROM profiles WHERE id = NEW.user_a;
+  SELECT name INTO user_b_name FROM profiles WHERE id = NEW.user_b;
+
+  -- Push to user_a about user_b
+  PERFORM send_push_notification(NEW.user_a, jsonb_build_object(
+    'title', 'C''est un match !',
+    'body', user_b_name || ' veut te rencontrer ce soir',
+    'tag', 'cesoir-match',
+    'url', '/chat/' || NEW.id,
+    'chatUrl', '/chat/' || NEW.id,
+    'profileUrl', '/profile/' || NEW.user_b
+  ));
+  -- Push to user_b about user_a
+  PERFORM send_push_notification(NEW.user_b, jsonb_build_object(
+    'title', 'C''est un match !',
+    'body', user_a_name || ' veut te rencontrer ce soir',
+    'tag', 'cesoir-match',
+    'url', '/chat/' || NEW.id,
+    'chatUrl', '/chat/' || NEW.id,
+    'profileUrl', '/profile/' || NEW.user_a
+  ));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_new_match_push
+  AFTER INSERT ON conversations
+  FOR EACH ROW EXECUTE FUNCTION on_new_match_send_push();
+
+-- ─────────────────────────────────────────
+-- Trigger 2: new chat message
+-- Fires on messages INSERT, pushes to the recipient (the OTHER user in the
+-- conversation). Skips if recipient is the sender (defensive).
+-- Respects user_settings.notifications_prefs.messages = false.
+-- ─────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION on_new_message_send_push() RETURNS TRIGGER AS $$
+DECLARE
+  recipient_id UUID;
+  sender_name  TEXT;
+  prefs        JSONB;
+  preview      TEXT;
+BEGIN
+  SELECT
+    CASE WHEN c.user_a = NEW.sender_id THEN c.user_b ELSE c.user_a END
+  INTO recipient_id
+  FROM conversations c WHERE c.id = NEW.conversation_id;
+
+  IF recipient_id IS NULL OR recipient_id = NEW.sender_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Honor user settings
+  SELECT notifications_prefs INTO prefs
+  FROM user_settings WHERE user_id = recipient_id;
+  IF prefs IS NOT NULL AND (prefs->>'messages')::boolean = false THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT name INTO sender_name FROM profiles WHERE id = NEW.sender_id;
+  preview := LEFT(COALESCE(NEW.content, ''), 80);
+
+  PERFORM send_push_notification(recipient_id, jsonb_build_object(
+    'title', sender_name,
+    'body', preview,
+    'tag', 'cesoir-message',
+    'url', '/chat/' || NEW.conversation_id,
+    'chatUrl', '/chat/' || NEW.conversation_id
+  ));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_new_message_push
+  AFTER INSERT ON messages
+  FOR EACH ROW EXECUTE FUNCTION on_new_message_send_push();
+```
+**Verify column names** before applying — confirm `conversations.user_a`/`user_b` and `messages.sender_id`/`conversation_id`/`content` match the actual schema (see `src/lib/supabase-types.generated.ts`).
+
+### Step 7 — Settings page wiring (1.5h)
+**File:** `src/app/(app)/profile/notifications/page.tsx` (edit existing)
+
+Add a master push toggle ABOVE the per-event toggles. The per-event toggles already exist and write to `user_settings.notifications_prefs` — those control whether a given user receives a push for that event type (the trigger reads them). The new master toggle controls the BROWSER permission + subscription.
+
+Insert near line 113 (just inside the main `<div>`, before `<h1>`):
+```tsx
+import { usePushNotifications } from "@/lib/usePushNotifications";
+
+// ... inside component
+const push = usePushNotifications();
+
+const handlePushToggle = async () => {
+  if (push.isSubscribed) {
+    await push.unsubscribe();
+  } else {
+    const ok = await push.subscribe();
+    if (!ok && push.permission === "denied") {
+      // Permission denied — show how to re-enable in browser settings
+      toast("Tu as bloqué les notifications. Active-les dans les réglages du navigateur.", "error");
+    }
+  }
+};
+
+// Render block (place above the existing toggles list):
+<div className="mb-4 p-4 rounded-2xl border border-accent/40 bg-accent/5">
+  <div className="flex items-center justify-between gap-3">
+    <div className="flex-1">
+      <p className="text-[14px] font-bold">Notifications push</p>
+      <p className="text-[11px] text-text-muted">
+        {!push.isSupported
+          ? "Ton navigateur ne supporte pas les notifications push"
+          : push.permission === "denied"
+            ? "Bloquees — debloque dans les reglages du navigateur"
+            : push.isSubscribed
+              ? "Activees - tu recevras les nouveaux matchs et messages"
+              : "Recois un signal quand tu as un match ou un message"}
+      </p>
+    </div>
+    <button
+      role="switch"
+      aria-checked={push.isSubscribed}
+      aria-label="Notifications push"
+      disabled={!push.isSupported || push.permission === "denied" || push.isLoading}
+      onClick={handlePushToggle}
+      className={`relative w-12 h-7 rounded-full transition-colors disabled:opacity-50 ${
+        push.isSubscribed ? "bg-accent" : "bg-border"
+      }`}
+    >
+      <span className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full transition-transform shadow-sm ${
+        push.isSubscribed ? "translate-x-5" : "translate-x-0"
+      }`} />
+    </button>
+  </div>
+</div>
+```
+
+### Step 8 — Permission UX framing (post-first-match prompt) (2h)
+**File:** `src/components/app/MatchCinematic.tsx` (edit) OR new `src/components/app/PushPermissionPrompt.tsx`.
+
+Per WCAG / HIG / Mozilla guidance: never call `Notification.requestPermission()` cold. Always show a custom in-app dialog explaining the value FIRST, then call the native prompt only if the user accepts.
+
+**Trigger logic** (file: `src/lib/useFirstMatchPushPrompt.ts`, new):
+- Listen for the same realtime channel `MatchCinematic` listens to (or piggyback on its callback)
+- On the user's FIRST EVER match (count = 1 in conversations), set localStorage flag `cesoir_pushPromptSeen = true` and show the soft prompt 5 seconds AFTER the cinematic dismisses
+- If `Notification.permission !== "default"` skip entirely (already decided)
+
+**Soft prompt UI**:
+- Bottom sheet, dismissable, 2 CTAs:
+  - "Activer les notifications" → calls `push.subscribe()`
+  - "Plus tard" → dismiss, sets flag, never re-shown automatically (re-prompt only via /profile/notifications page)
+- Copy: *"Active les notifications pour ne rater aucun match. Tu peux les couper a tout moment dans tes reglages."*
+
+**A11y**:
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at the title
+- Focus trap inside the sheet (already a pattern in the codebase — see `MatchCinematic`)
+- ESC closes (treat as "Plus tard")
+
+### Step 9 — Update account-deletion cleanup (10 min)
+**File:** `src/app/api/account/delete/route.ts`
+
+Already lists `push_subscriptions` in `TABLES_TO_CLEAN` (line 105). Once the table exists, deletion will cascade automatically via the FK constraint. **No change needed**, but verify the route still passes its tests after the migration is applied.
+
+---
+
+## 4. Risks & Mitigations
+
+### iOS Safari restrictions
+- **iOS 16.4+ required** — push only works on iOS when the PWA is INSTALLED to home screen via "Add to Home Screen". Browser tab notifications do not work.
+- **No notifications in Safari tab** — even installed PWA apps can be denied if the user is in iOS Low Power Mode, Focus Mode, or Do Not Disturb.
+- **Mitigation:** detect iOS + non-installed state, show a "Install CeSoir to receive notifications" prompt instead of the push toggle. Use `window.matchMedia('(display-mode: standalone)').matches`.
+
+### Chrome FCM quirks
+- Chrome's push endpoint is `fcm.googleapis.com/wp/...`. No additional config needed (web-push handles it), but FCM has its own anti-spam: if you push too frequently to one user, FCM may throttle.
+- **Mitigation:** respect user_settings.notifications_prefs (already wired in trigger); add a per-user rate limit later (P1) if abuse appears.
+
+### Denied permission flow
+- Once a user clicks "Block" on the native prompt, you cannot re-prompt. Browser only re-prompts after the user manually clears site permissions.
+- **Mitigation:**
+  - Always show our own custom prompt FIRST (step 8)
+  - On the settings page, when `permission === "denied"`, render text explaining how to re-enable in browser settings (not a button)
+  - Track via PostHog: `push_permission_blocked` event for funnel analysis
+
+### Unsubscribe flow
+- If a user disables push and re-enables, `pushManager.subscribe()` returns the SAME subscription (idempotent). The `upsert` in step 4 handles this.
+- If the browser invalidates a subscription (extension change, profile reset), the next push call returns 410 Gone. The `send` route in step 5 already deletes stale endpoints on 404/410.
+
+### Service Worker race
+- The push handler runs even if the page is closed. If a payload references `/chat/<convId>` and the user has not opened the app since the conversation was created, navigation works as expected (Next.js will server-render with auth).
+- **Risk:** `notificationclick` opens a new window if no existing tab. Make sure the start URL doesn't redirect to `/login` when user is logged in via cookie. Confirmed — `(app)/layout.tsx` reads the session.
+
+### Cross-device duplicates
+- A user with push enabled on phone + desktop will get TWO notifications per match. This is the standard web-push behaviour and what users expect on Android. iOS will only get one because PWAs are per-device-installed.
+- **No mitigation needed.** Note in product copy.
+
+---
+
+## 5. Estimated Effort
+
+| Step | Description | Hours |
+|------|-------------|-------|
+| 1 | Generate VAPID keys | 0.1 |
+| 2 | Add env vars (.env.sample + Vercel) | 0.2 |
+| 3 | Migration `029_push_subscriptions.sql` | 0.5 |
+| 4 | API route POST/DELETE `/api/push/subscribe` + hook auth wiring | 1.5 |
+| 5 | API route POST `/api/push/send` (web-push lib + secret check) | 2.0 |
+| 6 | Postgres triggers `030_push_triggers.sql` | 2.0 |
+| 7 | Settings page master toggle | 1.5 |
+| 8 | Soft prompt + first-match trigger | 2.0 |
+| 9 | Account deletion verify | 0.2 |
+| - | Manual QA (Chrome desktop + Android Chrome + iOS PWA install) | 2.0 |
+| - | PostHog event wiring + monitoring dashboard | 1.0 |
+| - | Buffer / debug | 1.0 |
+| **Total** | | **~14 hours** |
+
+---
+
+## 6. Success Metrics
+
+Track in PostHog from day 1.
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| **Opt-in rate** | 35% within 7 days of release | % of active users who allow push permission. Cold = ~15-20%; with post-first-match framing, target 35%. Tinder/Bumble industry benchmark = 40-50%. |
+| **Subscription persistence** | 80% after 30 days | % of users still subscribed 30 days after opting in. Drops indicate value disconnect. |
+| **Push delivery rate** | >95% | (Pushes sent / Pushes acknowledged by browser endpoint). Failures here = browser/OS issues, not our bug. |
+| **Click-through rate (matches)** | 35% within 1h | Users who tap the match push within 1h of receiving it. Anything <20% = framing/timing problem. |
+| **Click-through rate (messages)** | 50% within 1h | Higher because users actively want to read messages. <30% = we're sending too late or too noisy. |
+| **D1 retention delta** | +5pp for opt-in users | Push opt-ins should retain better than non-opt-ins. If not, push is annoying. |
+| **Permission blocked rate** | <8% | % of users who hit "Block" on native prompt. >15% = our soft prompt is failing to convince. |
+
+PostHog events to fire:
+- `push_soft_prompt_shown` — soft prompt displayed
+- `push_soft_prompt_accepted` — user clicked "Activer"
+- `push_soft_prompt_dismissed` — user clicked "Plus tard" or closed
+- `push_permission_granted` — `Notification.requestPermission()` returned "granted"
+- `push_permission_blocked` — returned "denied"
+- `push_subscribed` — full subscribe flow completed
+- `push_unsubscribed` — user disabled in settings
+- `push_received` — fired by SW push handler (post a beacon to `/api/analytics/push-received`)
+- `push_clicked` — fired by SW notificationclick handler
+
+---
+
+## 7. Out of Scope (followups)
+
+- Push for `like_received`, `plan_invite`, `feed_reaction` — wire as P1 once base case works
+- Rich notifications with image attachments (Tinder-style match preview with photo) — needs `image` field in showNotification options + CDN-hosted thumbnail
+- Push scheduling (e.g. "ce soir 19h, ton mode est actif!") — needs a cron + the scheduling primitives we already use for invite expirations
+- Notification grouping (badge count on PWA icon) — `navigator.setAppBadge()` API, separate spec
+- Per-conversation mute (mute push for a single chat) — UI affordance + new column on `conversations`

--- a/audit/round4/WAVE-16-STRIPE-READINESS.md
+++ b/audit/round4/WAVE-16-STRIPE-READINESS.md
@@ -1,0 +1,228 @@
+# Wave 16 — Stripe Activation Readiness Report
+
+**Date:** 2026-04-27
+**Project:** cesoir-app (Next.js 16, Vercel)
+**Bet #1 RICE:** 240 (very high impact, very low effort once gaps closed)
+**Verdict (TL;DR):** **Readiness 6/10 — NO-GO until 3 hard blockers fixed.**
+
+The integration code is **excellent** — clean architecture, signed webhooks, server-side flag enforcement, RLS-protected tables, validated metadata, rate limits, fail-safe defaults. **Flipping the boolean alone will produce a broken paywall** because the Stripe products/price IDs do not yet exist. Estimated **2.5–4 h** of operational work + **30 min** of code change to ship safely.
+
+---
+
+## 1. Flag Inventory
+
+### Definition
+- **`src/lib/featureFlags.ts:33`** — `monetizationEnabled: false` (single source of truth, exported as `MONETIZATION_ENABLED` and `FEATURE_FLAGS.monetizationEnabled`)
+- **`src/lib/featureFlags.ts:44-47`** — `isMonetizationEnabledServer()` requires **both** the client flag **AND** `process.env.STRIPE_ENABLED === "true"` (defence-in-depth, lets staging flip env without rebuild)
+
+### Consumers (15 sites — all gated correctly)
+
+| File | Line(s) | Behavior when flipped |
+|---|---|---|
+| `src/lib/premium-gate.ts` | 41, 78 | Stops returning `true` for everyone → re-applies free-tier daily-like cap (100/day) |
+| `src/lib/useSubscription.ts` | 64, 101, 115, 147 | Hook starts hitting `/api/stripe/checkout`, `/api/stripe/portal` instead of short-circuiting |
+| `src/lib/useRoses.ts` | 120, 121, 130, 169, 180 | Roses become finite (was UNLIMITED_ROSES) — users must pay or earn them |
+| `src/lib/useSwipeUndo.ts` | 91, 97 | Undo stops being free for non-premium |
+| `src/app/(app)/premium/page.tsx` | 89, 107 | Stops redirecting to `/why-free`, renders the paywall picker |
+| `src/app/(app)/shop/page.tsx` | 54, 68 | Stops redirecting, renders rose/boost packs |
+| `src/app/(app)/browse/page.tsx` | 406, 410 | Surfaces upsell CTAs in the browse footer |
+| `src/components/venues/VenueDashboard.tsx` | 249, 515, 518, 522 | "Activer Featured" goes from disabled to live |
+| `src/app/api/stripe/checkout/route.ts` | 44 | 503 → 200 with Checkout URL |
+| `src/app/api/stripe/portal/route.ts` | 34 | 503 → 200 with portal URL |
+| `src/app/api/stripe/webhook/route.ts` | 241 | 503 → 200, processes events |
+
+> **Important:** since the server side reads `process.env.STRIPE_ENABLED === "true"`, the client flag flip alone is **not** enough — the env var must be set on Vercel too, otherwise the API routes keep returning 503.
+
+---
+
+## 2. Stripe Integration Audit
+
+### Files present
+
+| Path | Status | Notes |
+|---|---|---|
+| `src/lib/stripe/server.ts` | ✅ | Pinned API version `2026-03-25.dahlia`, placeholder fallback for build, `isStripeConfigured()` helper |
+| `src/lib/stripe/client.ts` | ✅ | Singleton `loadStripe()`, gracefully returns null if pk missing |
+| `src/lib/stripe/plans.ts` | ⚠️ | **All 7 price IDs are placeholders** (`price_REPLACE_ME_*`) — code is correct, data is not |
+| `src/app/api/stripe/checkout/route.ts` | ✅ | Auth + rate limit + zod + price-ID whitelist + customer reuse + trial wiring |
+| `src/app/api/stripe/portal/route.ts` | ✅ | Auth + rate limit + zod + customer lookup |
+| `src/app/api/stripe/webhook/route.ts` | ✅ | **Signature verified**, raw body, service-role client, 7 event types |
+| `supabase/migrations/006_stripe_subscriptions_purchases.sql` | ✅ | Tables `subscriptions` + `purchases`, RLS (self-select/update only), service-role-only inserts |
+| `STRIPE_SETUP.md` | ✅ | Comprehensive walkthrough, test cards, Vercel CLI commands |
+| `src/lib/premium-gate.test.ts` | ✅ | 11 unit tests (isPremium, getDailyLikeCap, edge cases) |
+
+### Env variables expected (from `.env.sample`)
+
+| Var | Required for | Status (sample file) |
+|---|---|---|
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Client-side `loadStripe()` | Placeholder `pk_test_REPLACE_ME` |
+| `STRIPE_SECRET_KEY` | Server API routes | Placeholder `sk_test_REPLACE_ME` |
+| `STRIPE_WEBHOOK_SECRET` | Webhook signature verification | Placeholder `whsec_REPLACE_ME` |
+| `STRIPE_ENABLED` | **Required by `isMonetizationEnabledServer`** | ❌ **Not in `.env.sample`** — will silently fail |
+| `SUPABASE_SERVICE_ROLE_KEY` | Webhook RLS bypass | Already used elsewhere |
+| `NEXT_PUBLIC_APP_URL` | Stripe redirect URLs (optional) | Optional, falls back to Origin/Host |
+
+### Dependencies (package.json)
+- ✅ `stripe@^22.0.2` (server)
+- ✅ `@stripe/stripe-js@^9.2.0` (client)
+
+---
+
+## 3. Gap Analysis
+
+### 3.1 Webhook signature verification
+**Status: ✅ DONE**
+- `webhook/route.ts:261` calls `stripe.webhooks.constructEvent(rawBody, signature, WEBHOOK_SECRET)` correctly
+- Raw body read via `await request.text()` (line 257), `runtime = "nodejs"`, `dynamic = "force-dynamic"` set
+- Returns 400 on invalid signature, 503 if secret missing
+- Idempotency handled by `upsert` on `stripe_subscription_id` / `stripe_payment_intent_id`
+
+### 3.2 Price IDs hardcoded vs env-configured
+**Status: ⚠️ NEEDS REVIEW (intentional design choice)**
+- Price IDs are hardcoded in `src/lib/stripe/plans.ts` as a **whitelist** (security: prevents `price_<malicious>` from reaching `stripe.checkout.sessions.create`)
+- This is the **right pattern** — env-driven price IDs would weaken validation
+- BUT all 7 are placeholders: `price_REPLACE_ME_monthly`, `price_REPLACE_ME_annual`, `price_REPLACE_ME_roses_5/15/30`, `price_REPLACE_ME_boosts_3/10`
+- **Action:** create the 7 products in Stripe Dashboard → copy real `price_xxx` → edit `plans.ts` → commit
+
+### 3.3 Success / cancel redirect URLs
+**Status: ✅ DONE**
+- `resolveBaseUrl()` (checkout:27, portal:19) handles 3 cases in priority order:
+  1. `process.env.NEXT_PUBLIC_APP_URL` (explicit override)
+  2. `request.headers.get("origin")` (browser-driven)
+  3. `request.headers.get("host")` (proxy fallback, picks `https` unless localhost)
+- Will work on `cesoir-app.vercel.app` and on a custom domain without code change
+- **Optional improvement:** set `NEXT_PUBLIC_APP_URL=https://cesoir.app` (or whatever the prod domain is) on Vercel for explicitness
+
+### 3.4 TODO/FIXME in Stripe code
+**Status: ✅ NONE FOUND**
+- `grep -r "TODO|FIXME|XXX|HACK"` against `src/app/api/stripe` and `src/lib/stripe` returns 0 matches
+- Code reads as production-grade
+
+### 3.5 Test coverage
+**Status: ⚠️ NEEDS REVIEW**
+- ✅ `src/lib/premium-gate.test.ts` — 11 unit tests (free-tier cap, premium-tier Infinity, status edge cases)
+- ❌ **No tests** for `/api/stripe/checkout`, `/api/stripe/portal`, `/api/stripe/webhook` routes themselves
+- ❌ No integration test using Stripe CLI fixtures (`stripe trigger checkout.session.completed`)
+- **Risk:** a regression in body-parsing or zod schema would only be caught in prod
+- **Recommendation:** before flipping, run the manual checklist in `STRIPE_SETUP.md` §6 end-to-end with `stripe listen` forwarding
+
+### 3.6 DB schema
+**Status: ✅ DONE**
+- Migration 006 exists, defines `subscriptions` (8 statuses CHECK) + `purchases` (4 statuses CHECK)
+- RLS enabled, SELECT/UPDATE self-only, INSERT/DELETE service-role-only
+- All needed indexes present (`user_id`, `stripe_*_id`, `status`, `customer_id`)
+- `updated_at` trigger on subscriptions
+- **Verify:** confirm migration is applied in Supabase prod (`SELECT * FROM information_schema.tables WHERE table_name IN ('subscriptions','purchases')`)
+
+### 3.7 Stripe Customer Portal configuration
+**Status: ❌ MISSING (manual Stripe Dashboard step)**
+- Code calls `stripe.billingPortal.sessions.create()` (`portal/route.ts:109`)
+- Stripe **requires** the portal to be activated on the dashboard before sessions can be created
+- Without this: `/api/stripe/portal` returns 500 "Impossible d'ouvrir le portail de facturation"
+
+### 3.8 Webhook endpoint registration
+**Status: ❌ MISSING**
+- Code is ready to receive, but no endpoint registered on Stripe Dashboard yet
+- 7 events expected: `checkout.session.completed`, `customer.subscription.{created,updated,deleted,trial_will_end}`, `invoice.{paid,payment_failed}`, `payment_intent.succeeded`
+
+### 3.9 TypeScript strictness on webhook payloads
+**Status: ⚠️ NEEDS REVIEW (works but uses casts)**
+- Lines 195 + 204 in `webhook/route.ts` cast `invoice` to `{ subscription?: string | Stripe.Subscription }`
+- Reason: the pinned API version `2026-03-25.dahlia` returns `subscription` on Invoice, but the SDK type may not reflect it cleanly
+- Acceptable but worth re-checking on first real `invoice.paid` event in test mode
+
+### 3.10 Rate limiting
+**Status: ✅ DONE (10/min/user on checkout + portal), ⚠️ Upstash recommended for prod**
+- Without `UPSTASH_REDIS_REST_URL` set, rate limit is in-memory per Lambda → 5 instances × 10 = 50 attempts/min possible
+- See `.env.sample:34-44` — already documented
+
+---
+
+## 4. Activation Steps (in order)
+
+### Phase A — Stripe Dashboard (45 min, zero code)
+1. Create Stripe account on `mr.guessousyoussef@gmail.com`, stay in **Test mode**
+2. Get `pk_test_xxx` + `sk_test_xxx` from https://dashboard.stripe.com/test/apikeys
+3. Create 2 subscription products + 5 one-time products (see `STRIPE_SETUP.md` §2 for exact names/prices)
+4. Activate **Customer Portal** at https://dashboard.stripe.com/test/settings/billing/portal (logo, allow cancel + update card + view history)
+5. Create Webhook endpoint pointing at `https://<vercel-domain>/api/stripe/webhook` with the 7 events listed in §3.8 → copy `whsec_xxx`
+
+### Phase B — Code (30 min)
+6. **`.env.sample`**: add `STRIPE_ENABLED=false` line (with comment explaining flip mechanic)
+7. **`src/lib/stripe/plans.ts`**: replace the 7 `price_REPLACE_ME_*` with real `price_xxx` from Phase A step 3
+8. **`src/lib/featureFlags.ts:33`**: flip `monetizationEnabled: false` → `monetizationEnabled: true`
+9. Commit (e.g., `feat(stripe): activate monetization for Wave 16`)
+
+### Phase C — Vercel env vars (15 min)
+10. Add 4 production env vars on Vercel:
+    - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx`
+    - `STRIPE_SECRET_KEY=sk_test_xxx`
+    - `STRIPE_WEBHOOK_SECRET=whsec_xxx`
+    - `STRIPE_ENABLED=true`
+11. Optional: `NEXT_PUBLIC_APP_URL=https://<prod-domain>`
+12. Trigger redeploy (env var change does not auto-redeploy in all Vercel plans)
+
+### Phase D — Smoke test (45–60 min)
+13. Open prod `/premium` → 2 plans render with real prices (9.99 / 59.99 EUR)
+14. Click "Essai gratuit 7 jours" → redirect to Stripe Checkout
+15. Pay with `4242 4242 4242 4242` (CVC 123, exp 12/34) → redirect back to `/premium?status=success`
+16. Verify Supabase: `SELECT * FROM subscriptions WHERE user_id = <test_user>` → row with `status = 'trialing'`
+17. Reload `/premium` → CTA changed to "Gérer ma subscription" → click → Stripe Billing Portal opens
+18. Cancel sub in portal → verify `cancel_at_period_end = true` in DB
+19. Test `/shop` → buy 1 rose pack → verify row in `purchases` table
+
+### Phase E — Live mode promotion (when ready, separate go-live decision)
+20. Complete Stripe KYC (IBAN, business address)
+21. Recreate the 7 products in **Live mode** (Test mode products are not shared)
+22. Update `plans.ts` with new live `price_xxx`, swap env vars to `pk_live_xxx` / `sk_live_xxx`, recreate webhook in Live, swap `STRIPE_WEBHOOK_SECRET`
+
+---
+
+## 5. Time Estimate (to flip safely)
+
+| Phase | Time | Can be parallelized? |
+|---|---|---|
+| A — Stripe Dashboard setup | 45 min | No (needs human in browser) |
+| B — Code changes + commit | 30 min | After A |
+| C — Vercel env vars + redeploy | 15 min | After B |
+| D — Manual smoke test | 45–60 min | After C |
+| **Total (Test mode)** | **~2.5–3 h** | One person, one sitting |
+| E — Live mode promotion | 1–2 h + KYC waiting time | Separate go-live |
+
+---
+
+## 6. Risk Assessment (per gap if skipped)
+
+| If you flip without… | What breaks | Severity |
+|---|---|---|
+| Setting `STRIPE_ENABLED=true` env on Vercel | Every API route returns 503 — paywall shows but checkout fails silently | 🔴 **Critical** (UX disaster) |
+| Replacing `price_REPLACE_ME_*` in `plans.ts` | Stripe rejects `price_REPLACE_ME_monthly` → 400 → user sees "Impossible de créer la session de paiement" | 🔴 **Critical** |
+| Registering the webhook on Stripe Dashboard | Subscriptions created via Checkout never write to `subscriptions` table → user pays but app keeps treating them as free | 🔴 **Critical** (revenue + trust loss) |
+| Activating Customer Portal in Stripe Dashboard | `/api/stripe/portal` returns 500, users can't cancel/update card → support tickets | 🟠 **High** |
+| Setting `STRIPE_WEBHOOK_SECRET` env on Vercel | Webhook returns 400 "Invalid signature" → same effect as missing webhook | 🔴 **Critical** |
+| Confirming migration 006 is applied in prod DB | Webhook upserts to non-existent table → 500 on every event → Stripe retries indefinitely | 🔴 **Critical** |
+| Setting Upstash Redis env vars | Rate limit per-Lambda → ~50 checkout attempts/min/user instead of 10 → minor brute-force surface | 🟡 **Medium** |
+| Smoke test before announcing | First real customer is your QA → high-visibility bug if any of the above is wrong | 🟠 **High** |
+
+---
+
+## 7. Final Score & Recommendation
+
+### Readiness: **6 / 10**
+- Code: **9/10** (production-grade, no TODOs, signed webhooks, RLS, zod, rate limits)
+- Data: **2/10** (price IDs are placeholders, no Stripe account configured)
+- Ops: **3/10** (no dashboard products, no webhook endpoint, no portal activated, env vars absent)
+- Tests: **5/10** (good unit coverage on premium-gate, no integration tests on routes)
+
+### Verdict: **NO-GO** for "just flip the flag" — but **GO** for a 3-hour deliberate activation session
+
+### Top 3 Blockers
+1. **Stripe products do not exist** → 7 placeholders in `plans.ts` will cause 400 on checkout (Phase A step 3 + Phase B step 7)
+2. **`STRIPE_ENABLED` env var is missing** from `.env.sample` and Vercel — server-side `isMonetizationEnabledServer()` returns false even after flag flip (Phase B step 6 + Phase C step 10)
+3. **Webhook not registered + portal not activated** in Stripe Dashboard → subscriptions silently broken even if checkout succeeds (Phase A steps 4–5)
+
+### Recommended Path
+- Block out a **3-hour focused session** (one person, one sitting)
+- Follow Phase A → B → C → D in order, do not parallelize
+- Stay in **Test mode** for at least one week of internal usage before Phase E (Live promotion)
+- After Phase D, schedule a follow-up agent in 7 days to verify no `customer.subscription.*` event got dropped on retry — see Wave 16 Bet #2 if applicable

--- a/src/app/(app)/browse/page.tsx
+++ b/src/app/(app)/browse/page.tsx
@@ -23,6 +23,7 @@ import NotificationPreview from "@/components/app/NotificationPreview";
 import MidnightReset from "@/components/app/MidnightReset";
 import PageHeader from "@/components/ui/PageHeader";
 import { RotateCcw } from "@/components/ui/lucide";
+import PageLoader from "@/components/app/PageLoader";
 import { playSound } from "@/lib/sounds";
 import { haptics } from "@/lib/haptics";
 import { useSwipeUndo } from "@/lib/useSwipeUndo";
@@ -97,12 +98,8 @@ function BrowsePageInner() {
   // Find the original MatchCandidate for the current card (needed for mode info on like/superlike)
   const currentMatch = matches.find((m) => m.id === card?.id);
 
-  useEffect(() => {
-    if (match) {
-      const t = setTimeout(() => setMatch(null), 4000);
-      return () => clearTimeout(t);
-    }
-  }, [match]);
+  // Auto-dismiss is now self-managed inside MatchCinematic (8s default,
+  // pausable on hover/tap). See src/components/app/MatchCinematic.tsx.
 
   // Reset index when filter or matches change
   useEffect(() => {
@@ -410,14 +407,14 @@ function BrowsePageInner() {
             {MONETIZATION_ENABLED ? (
               <Link
                 href="/premium"
-                className="inline-block gradient-bg text-white px-8 py-3 rounded-full text-[14px] font-semibold"
+                className="inline-block gradient-bg text-white px-8 py-3 rounded-full text-[14px] font-semibold tap-target"
               >
                 Passer Premium
               </Link>
             ) : (
               <Link
                 href="/why-free"
-                className="inline-block gradient-bg text-white px-8 py-3 rounded-full text-[14px] font-semibold"
+                className="inline-block gradient-bg text-white px-8 py-3 rounded-full text-[14px] font-semibold tap-target"
               >
                 Pourquoi gratuit ?
               </Link>
@@ -493,13 +490,17 @@ function ActionButtons({
     // home bar. Bumped to 96px + safe-area so circles always sit fully above
     // the glass nav. Pair with pt-2 for symmetric spacing above.
     <div className="shrink-0 pt-2 pb-[calc(96px+env(safe-area-inset-bottom))]" role="group" aria-label="Actions">
-      {/* Small undo icon above main row */}
+      {/* Small undo icon above main row.
+          Visual stays 28px (compact above the 60px main row) but the
+          tap-target-expand utility renders a 44px invisible hit area
+          via ::before so we still meet WCAG 2.5.5 / Apple HIG.
+          Sweep 2026-04-27. */}
       <div className="flex justify-center mb-2">
         <motion.button
           onClick={onUndo}
           disabled={!canUndo}
           aria-label="Annuler le dernier swipe"
-          className={`w-7 h-7 rounded-full flex items-center justify-center transition-all ${
+          className={`tap-target-expand w-7 h-7 rounded-full flex items-center justify-center transition-all ${
             canUndo
               ? "text-text-muted hover:text-text"
               : "text-text-muted/20 cursor-not-allowed"
@@ -606,7 +607,7 @@ function EmptyState({ onReset }: { onReset: () => void }) {
 // Same pattern as feed/plans/plans-create after /glowup/suspense-boundaries PR.
 export default function BrowsePage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<PageLoader />}>
       <BrowsePageInner />
     </Suspense>
   );

--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -295,7 +295,7 @@ export default function ChatPage() {
                 // TODO: open chat composer with prefilled icebreaker text
                 console.log("[icebreaker] selected (no composer wired yet):", ice.text);
               }}
-              className="shrink-0 bg-accent/5 border border-accent/15 rounded-xl px-3.5 py-2.5 text-left max-w-[200px] hover:border-accent/30 transition-colors tap-target"
+              className="shrink-0 bg-accent/5 border border-accent/15 rounded-xl px-3.5 py-2.5 text-left max-w-[240px] hover:border-accent/30 transition-colors tap-target"
             >
               <span className="text-[10px] text-accent font-semibold block mb-1">{ice.mode} Suggestion</span>
               <span className="text-[12px] text-text-soft leading-snug line-clamp-2">{ice.text}</span>

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -14,7 +14,7 @@
  * enhancement (kept client-local for now — no deep-link requirement yet).
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { m, type Variants } from "motion/react";
 import PageHeader from "@/components/ui/PageHeader";
 import EmptyState from "@/components/ui/EmptyState";
@@ -22,9 +22,9 @@ import EventCard from "@/components/events/EventCard";
 import EventFilters from "@/components/events/EventFilters";
 import { useEvents } from "@/lib/useEvents";
 import type { EventFiltersState } from "@/lib/events-types";
-import { springs } from "@/lib/motion-design";
+import { springs, ambient } from "@/lib/motion-design";
 import { app } from "@/lib/design-tokens";
-import { Loader2 } from "@/components/ui/lucide";
+import { Calendar } from "@/components/ui/lucide";
 
 const DEFAULT_FILTERS: EventFiltersState = {
   when: "all",
@@ -55,6 +55,11 @@ export default function EventsPage() {
   const headingSubtitle = useMemo(() => {
     const parts = ["Ce soir", "Ce week-end", "Tout l'été"];
     return parts.join(" · ");
+  }, []);
+
+  const filtersActive = filters.when !== "all" || filters.category !== null;
+  const handleClearFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
   }, []);
 
   return (
@@ -98,14 +103,40 @@ export default function EventsPage() {
       {/* List */}
       <main className="px-4 pt-4 pb-32" aria-label="Liste des soirées">
         {loading && events.length === 0 ? (
-          <div className="flex items-center justify-center py-20 text-text-muted">
-            <Loader2
-              size={22}
-              className="animate-spin"
-              strokeWidth={1.8}
-              aria-label="Chargement"
-            />
-          </div>
+          <ul
+            className="space-y-4"
+            role="status"
+            aria-label="Chargement des soirées"
+          >
+            {Array.from({ length: 3 }).map((_, i) => (
+              <li
+                key={i}
+                className="overflow-hidden rounded-2xl border border-border bg-card animate-pulse"
+              >
+                {/* Flyer placeholder (16/9) */}
+                <div className="aspect-[16/9] w-full bg-border/50" />
+                <div className="space-y-3 p-4">
+                  {/* Date badge */}
+                  <div className="h-3 w-24 rounded bg-border/40" />
+                  {/* Title (2 lines) */}
+                  <div className="space-y-2">
+                    <div className="h-4 w-5/6 rounded bg-border/50" />
+                    <div className="h-4 w-3/5 rounded bg-border/50" />
+                  </div>
+                  {/* Venue */}
+                  <div className="h-3 w-2/3 rounded bg-border/30" />
+                  {/* Chips + CTA row */}
+                  <div className="flex items-center justify-between pt-2">
+                    <div className="flex gap-2">
+                      <div className="h-6 w-14 rounded-full bg-border/30" />
+                      <div className="h-6 w-14 rounded-full bg-border/30" />
+                    </div>
+                    <div className="h-8 w-20 rounded-full bg-border/40" />
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
         ) : error && events.length === 0 ? (
           <EmptyState
             emoji="⚠️"
@@ -113,12 +144,9 @@ export default function EventsPage() {
             subtitle="Vérifie ta connexion et réessaye dans un instant."
           />
         ) : events.length === 0 ? (
-          <EmptyState
-            emoji="🌙"
-            title="Rien de prévu pour ce moment"
-            subtitle="Les events Montpellier arrivent bientôt. Reviens vite."
-            actionLabel="Voir tout"
-            actionHref="/events"
+          <EventsEmptyState
+            filtersActive={filtersActive}
+            onClearFilters={handleClearFilters}
           />
         ) : (
           <m.ul
@@ -135,6 +163,101 @@ export default function EventsPage() {
           </m.ul>
         )}
       </main>
+    </div>
+  );
+}
+
+/**
+ * Empty state for the events list. Shows a calming Calendar icon, a localized
+ * copy that adapts to whether the user has filters active, and a CTA to clear
+ * filters (when active) or reload (when not). The "Voir tous les events" CTA
+ * resets the filter state so the user can see what is actually available.
+ */
+function EventsEmptyState({
+  filtersActive,
+  onClearFilters,
+}: {
+  filtersActive: boolean;
+  onClearFilters: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center px-6 py-16 text-center"
+      role="status"
+    >
+      {/* Glow aura behind the icon */}
+      <div className="relative mb-6">
+        <m.div
+          aria-hidden
+          className="absolute inset-0 rounded-full pointer-events-none"
+          style={{
+            background:
+              "radial-gradient(circle at 50% 50%, rgba(139,92,246,0.32), transparent 70%)",
+            filter: "blur(28px)",
+          }}
+          animate={{
+            opacity: [0.4, 0.75, 0.4],
+            scale: [0.9, 1.1, 0.9],
+          }}
+          transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+        />
+        <m.div
+          className="relative w-24 h-24 rounded-full flex items-center justify-center"
+          style={{
+            background:
+              "linear-gradient(135deg, rgba(139,92,246,0.15), rgba(0,255,136,0.08))",
+            boxShadow:
+              "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 24%, transparent)",
+          }}
+          animate={ambient.float(6)}
+        >
+          <Calendar
+            size={36}
+            strokeWidth={1.6}
+            className="text-accent"
+            aria-hidden
+          />
+        </m.div>
+      </div>
+
+      <m.h2
+        className="text-[17px] font-bold text-text mb-1.5"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...springs.heavy, delay: 0.1 }}
+      >
+        Pas de soirées dans ta zone
+      </m.h2>
+
+      <m.p
+        className="text-[13px] text-text-muted max-w-[300px] leading-relaxed mb-6"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...springs.heavy, delay: 0.2 }}
+      >
+        Élargis ton rayon ou attends que de nouveaux events soient ajoutés.
+      </m.p>
+
+      <m.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...springs.heavy, delay: 0.3 }}
+      >
+        <button
+          type="button"
+          onClick={onClearFilters}
+          disabled={!filtersActive}
+          className="inline-flex items-center gap-2 px-6 py-3 rounded-full text-[14px] font-bold text-white transition-all active:scale-95 tap-target disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{
+            background: app.gradient,
+            boxShadow:
+              "0 10px 30px color-mix(in srgb, var(--color-accent) 28%, transparent)",
+          }}
+        >
+          Voir tous les events
+          <span aria-hidden="true">{"→"}</span>
+        </button>
+      </m.div>
     </div>
   );
 }

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -9,6 +9,7 @@ import { MODES, type ModeKey } from "@/lib/modes";
 import { useFeed, type FeedActivity } from "@/lib/useFeed";
 import { useFeedReactions } from "@/lib/useFeedReactions";
 import EmptyState from "@/components/ui/EmptyState";
+import PageLoader from "@/components/app/PageLoader";
 import { Magnetic } from "@/components/motion/Magnetic";
 import PageHeader from "@/components/ui/PageHeader";
 import { SkeletonChatRow } from "@/components/ui/skeletons";
@@ -405,7 +406,7 @@ function FeedPageInner() {
 
 export default function FeedPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<PageLoader />}>
       <FeedPageInner />
     </Suspense>
   );

--- a/src/app/(app)/invites/mine/page.tsx
+++ b/src/app/(app)/invites/mine/page.tsx
@@ -14,20 +14,53 @@
  *  - Stats: total signups via my codes, total roses earned via referrals
  */
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { m } from "motion/react";
 import { useAuth } from "@/context/AuthContext";
 import { supabase } from "@/lib/supabase";
 import PageHeader from "@/components/ui/PageHeader";
 import { springs } from "@/lib/motion-design";
+import {
+  useReferralInfo,
+  ROSES_PER_CLAIM,
+  type ReferralCodeEntry,
+} from "@/lib/referral";
 
+/**
+ * Local InviteCode shape kept for the existing CodeCard which was written
+ * against snake_case (matches the API response too). The dashboard now
+ * derives codes from `useReferralInfo` and adapts them to this shape so
+ * we don't have to refactor CodeCard's props.
+ */
 interface InviteCode {
   code: string;
   used_by: string | null;
   used_at: string | null;
   expires_at: string;
   created_at: string;
+}
+
+function fromEntry(e: ReferralCodeEntry): InviteCode {
+  return {
+    code: e.code,
+    used_by: e.usedBy,
+    used_at: e.usedAt,
+    expires_at: e.expiresAt,
+    created_at: e.createdAt,
+  };
+}
+
+function timeAgo(iso: string): string {
+  const d = new Date(iso).getTime();
+  if (isNaN(d)) return "?";
+  const diffMs = Date.now() - d;
+  const days = Math.floor(diffMs / 86_400_000);
+  if (days <= 0) return "aujourd'hui";
+  if (days === 1) return "hier";
+  if (days < 7) return `il y a ${days}j`;
+  if (days < 30) return `il y a ${Math.floor(days / 7)} sem.`;
+  return `il y a ${Math.floor(days / 30)} mois`;
 }
 
 function fmtDate(iso: string): string {
@@ -117,7 +150,8 @@ function CodeCard({ code, onCopy }: { code: InviteCode; onCopy: (text: string) =
 
       {used && code.used_at ? (
         <div className="text-xs text-text-muted">
-          Utilisé le {fmtDate(code.used_at)}. Tu as gagné <span className="font-semibold text-text">5 🌹</span>.
+          Utilisé {timeAgo(code.used_at)} (le {fmtDate(code.used_at)}). Tu as gagné{" "}
+          <span className="font-semibold text-text">5 🌹</span>.
         </div>
       ) : !expired ? (
         <div className="flex gap-2">
@@ -143,30 +177,21 @@ function CodeCard({ code, onCopy }: { code: InviteCode; onCopy: (text: string) =
 
 export default function InvitesMinePage() {
   const { user, loading: authLoading } = useAuth();
-  const [codes, setCodes] = useState<InviteCode[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { info, loading, refetch } = useReferralInfo(user?.id ?? null);
   const [minting, setMinting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
-  const fetchCodes = useCallback(async () => {
-    setLoading(true);
-    const { data: sessionData } = await supabase.auth.getSession();
-    const token = sessionData.session?.access_token;
-    if (!token) {
-      setLoading(false);
-      return;
-    }
-    const res = await fetch("/api/invites/mine", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    const data = (await res.json()) as { codes?: InviteCode[]; error?: string };
-    if (data.codes) setCodes(data.codes);
-    setLoading(false);
-  }, []);
+  // Re-derive InviteCode list from the hook so the existing CodeCard JSX
+  // doesn't need to change. Realtime updates flow in via useReferralInfo
+  // (subscribed to invite_codes UPDATE/INSERT/DELETE for this user).
+  const codes: InviteCode[] = info.myCodes.map(fromEntry);
 
+  // Refetch when auth flips (token refresh, signin) — the hook's own
+  // userId dep handles the bulk of this, but keeping a refetch here is
+  // a no-op when info is already fresh and a useful safety net otherwise.
   useEffect(() => {
-    if (!authLoading && user) void fetchCodes();
-  }, [authLoading, user, fetchCodes]);
+    if (!authLoading && user) void refetch();
+  }, [authLoading, user, refetch]);
 
   async function handleMint() {
     setMinting(true);
@@ -180,7 +205,9 @@ export default function InvitesMinePage() {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });
-    await fetchCodes();
+    // Realtime should pick up the INSERTs, but refetch immediately to
+    // close the perceived latency window for the user who just clicked.
+    await refetch();
     setMinting(false);
   }
 
@@ -193,9 +220,11 @@ export default function InvitesMinePage() {
   const used = codes.filter((c) => c.used_by);
   const expired = codes.filter((c) => !c.used_by && new Date(c.expires_at) <= new Date());
 
-  // Each used code = +5 roses earned. Bookkeeping is server-side via
-  // user_wallet, but this is a useful reminder for the dashboard.
-  const rosesEarned = used.length * 5;
+  // Headline numbers come straight from the DB-backed hook so we get
+  // the correct count even when codes paginate or RLS changes.
+  const rosesEarned = info.totalRosesEarned;
+  const totalReferrals = info.totalReferrals;
+  const activeFounders = info.activeFounders;
 
   return (
     <div className="min-h-screen bg-bg pb-20">
@@ -206,7 +235,7 @@ export default function InvitesMinePage() {
       />
 
       <div className="px-4 pt-4 max-w-md mx-auto space-y-6">
-        {/* Stats banner */}
+        {/* Stats banner — numbers come from DB-backed `useReferralInfo` */}
         <m.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -214,8 +243,8 @@ export default function InvitesMinePage() {
           className="rounded-2xl border border-accent/30 bg-accent/5 p-4 flex items-center justify-around text-center"
         >
           <div>
-            <div className="font-display text-2xl font-bold text-text">{used.length}</div>
-            <div className="text-[10px] uppercase tracking-wider text-text-muted">Inscriptions</div>
+            <div className="font-display text-2xl font-bold text-text">{totalReferrals}</div>
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">Parrainés</div>
           </div>
           <div className="w-px h-8 bg-border" aria-hidden="true" />
           <div>
@@ -227,6 +256,43 @@ export default function InvitesMinePage() {
             <div className="font-display text-2xl font-bold text-text">{active.length}</div>
             <div className="text-[10px] uppercase tracking-wider text-text-muted">Codes actifs</div>
           </div>
+        </m.div>
+
+        {/* Plain-language stats lines — required by Wave 16 Bet #2 */}
+        <m.div
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={springs.snap}
+          className="rounded-2xl border border-border bg-card p-4 space-y-1.5 text-sm text-text"
+          aria-live="polite"
+        >
+          {totalReferrals === 0 ? (
+            <p className="text-text-muted">
+              Personne n&apos;a encore utilisé un de tes codes. Partages-en un pour démarrer ta chaîne.
+            </p>
+          ) : (
+            <>
+              <p>
+                Tu as parrainé <span className="font-semibold text-accent">{totalReferrals}</span>{" "}
+                {totalReferrals === 1 ? "ami" : "amis"}.
+              </p>
+              <p>
+                Tu as gagné <span className="font-semibold text-accent">{rosesEarned} 🌹</span>{" "}
+                grâce à tes invitations
+                <span className="text-text-muted">
+                  {" "}
+                  ({ROSES_PER_CLAIM} 🌹 par inscription).
+                </span>
+              </p>
+              {activeFounders > 0 && (
+                <p>
+                  <span className="font-semibold text-accent">{activeFounders}</span> de tes amis{" "}
+                  {activeFounders === 1 ? "porte" : "portent"} le badge{" "}
+                  <span className="font-semibold">Fondateur ☾</span>.
+                </p>
+              )}
+            </>
+          )}
         </m.div>
 
         {/* Active codes section */}

--- a/src/app/(app)/map/page.tsx
+++ b/src/app/(app)/map/page.tsx
@@ -819,8 +819,8 @@ export default function MapPage() {
                 <span className="text-[10px] text-accent font-semibold">Découvrir</span>
               </Link>
             </m.div>
-            <div className="text-[11px] text-text-muted">
-              {loading ? "Localisation..." : error ? <span className="text-danger">{error}</span> : <><span className="w-1.5 h-1.5 rounded-full bg-safe inline-block mr-1" /><m.span key={`count-${filtered.length}`} initial={{ opacity: 0, scale: 0.5 }} animate={{ opacity: 1, scale: 1 }} transition={springs.snap}>{filtered.length}</m.span></>}
+            <div className="text-[11px] text-text-muted min-w-0 max-w-[160px]">
+              {loading ? "Localisation..." : error ? <span className="text-danger block truncate" title={error}>{error}</span> : <><span className="w-1.5 h-1.5 rounded-full bg-safe inline-block mr-1" /><m.span key={`count-${filtered.length}`} initial={{ opacity: 0, scale: 0.5 }} animate={{ opacity: 1, scale: 1 }} transition={springs.snap}>{filtered.length}</m.span></>}
             </div>
           </div>
         }

--- a/src/app/(app)/plans/create/page.tsx
+++ b/src/app/(app)/plans/create/page.tsx
@@ -7,6 +7,7 @@ import { springs } from "@/lib/motion-design";
 import { usePlans, PLAN_TYPE_META, type PlanType } from "@/lib/usePlans";
 import PageHeader from "@/components/ui/PageHeader";
 import { useToast } from "@/components/ui/Toast";
+import PageLoader from "@/components/app/PageLoader";
 
 const PUBLIC_TYPES: PlanType[] = ["flash", "soiree", "popup"];
 
@@ -204,7 +205,7 @@ function CreatePlanPageInner() {
 
 export default function CreatePlanPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<PageLoader />}>
       <CreatePlanPageInner />
     </Suspense>
   );

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -213,7 +213,13 @@ function PlansPageInner() {
 
 export default function PlansPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-bg p-4">
+          <SkeletonList count={4} itemHeight={96} />
+        </div>
+      }
+    >
       <PlansPageInner />
     </Suspense>
   );

--- a/src/app/(app)/squad/page.tsx
+++ b/src/app/(app)/squad/page.tsx
@@ -185,15 +185,23 @@ export default function SquadPage() {
               className="flex-1 px-3 py-2.5 bg-bg border border-border rounded-xl text-sm text-text placeholder:text-text-muted focus:outline-none focus:border-accent font-mono tracking-wider"
               aria-label="Code d'invitation"
             />
-            {/* 4. "Rejoindre" button: whileHover scale:1.05 y:-2 with glow, whileTap scale:0.92 */}
+            {/* 4. "Rejoindre" button: whileHover scale:1.05 y:-2 with glow, whileTap scale:0.92
+                BUG-08 fix (2026-04-27): button quasi-invisible at smaller sizes when disabled
+                + low contrast against gradient. Bumped disabled opacity 40→60 (still readable),
+                added min-w-[88px] so it doesn't shrink under "Rejoindre", and a subtle text
+                shadow for legibility on the violet gradient. whileHover already preserves the
+                gradient (no bg override), only adds glow + lift. */}
             <m.button
               onClick={handleJoin}
               disabled={joinCode.length !== 6 || busy}
               whileHover={{ scale: 1.05, y: -2, boxShadow: "0 0 20px color-mix(in srgb, var(--color-accent) 40%, transparent)" }}
               whileTap={{ scale: 0.92 }}
               transition={springs.snap}
-              className="px-4 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 transition-opacity"
-              style={{ background: "linear-gradient(135deg, var(--color-accent), var(--color-accent-2))" }}
+              className="min-w-[88px] px-4 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-60 transition-opacity"
+              style={{
+                background: "linear-gradient(135deg, var(--color-accent), var(--color-accent-2))",
+                textShadow: "0 1px 2px rgba(0,0,0,0.2)",
+              }}
             >
               Rejoindre
             </m.button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import { m } from "motion/react";
 import { useAuth } from "@/context/AuthContext";
 import { landing } from "@/lib/design-tokens";
 import { easings } from "@/lib/motion-design";
+import { Eye, EyeOff, Loader2 } from "@/components/ui/lucide";
 import {
   FormField,
   FormInput,
@@ -49,6 +50,7 @@ function LoginPageInner() {
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -167,16 +169,36 @@ function LoginPageInner() {
           </FormField>
 
           <FormField label="Mot de passe" variant="dark" required>
-            <FormInput
-              type="password"
-              placeholder="********"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-              variant="dark"
-              size="lg"
-              error={Boolean(error)}
-            />
+            <div className="relative">
+              <FormInput
+                type={showPassword ? "text" : "password"}
+                placeholder="********"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                variant="dark"
+                size="lg"
+                error={Boolean(error)}
+                className="pr-12"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={
+                  showPassword
+                    ? "Masquer le mot de passe"
+                    : "Afficher le mot de passe"
+                }
+                aria-pressed={showPassword}
+                className="absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-11 h-11 rounded-lg text-white/60 hover:text-white/90 transition-colors"
+              >
+                {showPassword ? (
+                  <EyeOff size={20} aria-hidden="true" />
+                ) : (
+                  <Eye size={20} aria-hidden="true" />
+                )}
+              </button>
+            </div>
           </FormField>
 
           <div className="text-right">
@@ -203,7 +225,7 @@ function LoginPageInner() {
           Pas encore inscrit ?{" "}
           <Link
             href="/signup-quick"
-            className="font-semibold transition-opacity hover:opacity-80"
+            className="font-semibold transition-opacity hover:opacity-80 tap-target inline-flex items-center justify-center"
             style={{ color: landing.vert }}
           >
             Créer un compte
@@ -214,9 +236,22 @@ function LoginPageInner() {
   );
 }
 
+function LoginFallback() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-bg">
+      <Loader2
+        size={28}
+        strokeWidth={1.8}
+        className="animate-spin text-accent"
+        aria-label="Chargement"
+      />
+    </main>
+  );
+}
+
 export default function LoginPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<LoginFallback />}>
       <LoginPageInner />
     </Suspense>
   );

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -10,6 +10,7 @@ import { trackAcquisition, track, identifyUser, captureFirstVisit, trackFirstTim
 import PhotoUpload from "@/components/app/PhotoUpload";
 import { landing } from "@/lib/design-tokens";
 import { springs, easings } from "@/lib/motion-design";
+import { Eye, EyeOff, Loader2 } from "@/components/ui/lucide";
 import {
   FormField,
   FormInput,
@@ -47,11 +48,24 @@ const stepVariants = {
   },
 };
 
+function RegisterFallback() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-bg">
+      <Loader2
+        size={28}
+        strokeWidth={1.8}
+        className="animate-spin text-accent"
+        aria-label="Chargement"
+      />
+    </main>
+  );
+}
+
 // Wave 15.1 : wrap useSearchParams in Suspense to allow static prerender
 // (Next.js 16 requires Suspense around search-params readers for SSG).
 export default function RegisterPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<RegisterFallback />}>
       <RegisterPageInner />
     </Suspense>
   );
@@ -77,6 +91,7 @@ function RegisterPageInner() {
   const [age, setAge] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [gender, setGender] = useState("");
   const [lookingFor, setLookingFor] = useState("");
   const [bio, setBio] = useState("");
@@ -402,16 +417,36 @@ function RegisterPageInner() {
                   required
                   hint="Minimum 6 caractères."
                 >
-                  <FormInput
-                    type="password"
-                    minLength={6}
-                    placeholder="********"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    autoComplete="new-password"
-                    variant="dark"
-                    size="md"
-                  />
+                  <div className="relative">
+                    <FormInput
+                      type={showPassword ? "text" : "password"}
+                      minLength={6}
+                      placeholder="********"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      autoComplete="new-password"
+                      variant="dark"
+                      size="md"
+                      className="pr-12"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      aria-label={
+                        showPassword
+                          ? "Masquer le mot de passe"
+                          : "Afficher le mot de passe"
+                      }
+                      aria-pressed={showPassword}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-11 h-11 rounded-lg text-white/60 hover:text-white/90 transition-colors"
+                    >
+                      {showPassword ? (
+                        <EyeOff size={20} aria-hidden="true" />
+                      ) : (
+                        <Eye size={20} aria-hidden="true" />
+                      )}
+                    </button>
+                  </div>
                 </FormField>
                 <FormChoice
                   legend="Je suis"

--- a/src/app/(auth)/signup-quick/page.tsx
+++ b/src/app/(auth)/signup-quick/page.tsx
@@ -33,6 +33,7 @@ import { useGeolocation } from "@/lib/useGeolocation";
 import { supabase } from "@/lib/supabase";
 import { MODES, type ModeKey } from "@/lib/modes";
 import { easings, springs } from "@/lib/motion-design";
+import { Eye, EyeOff, Loader2 } from "@/components/ui/lucide";
 
 const PUBLIC_MODES: ModeKey[] = [
   "solo-diner",
@@ -85,6 +86,7 @@ function SignupQuickInner() {
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [age, setAge] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [selectedMode, setSelectedMode] = useState<ModeKey | null>(null);
@@ -318,19 +320,44 @@ function SignupQuickInner() {
               />
             </label>
 
-            <label className="block">
-              <span className="text-xs font-semibold text-text-muted">Mot de passe</span>
-              <input
-                type="password"
-                required
-                minLength={8}
-                autoComplete="new-password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="mt-1 w-full px-3 py-2.5 rounded-xl border border-border bg-card text-text focus:outline-none focus:ring-2 focus:ring-accent text-base"
-                placeholder="8 caractères minimum"
-              />
-            </label>
+            <div className="block">
+              <label
+                htmlFor="signup-quick-password"
+                className="text-xs font-semibold text-text-muted"
+              >
+                Mot de passe
+              </label>
+              <div className="relative mt-1">
+                <input
+                  id="signup-quick-password"
+                  type={showPassword ? "text" : "password"}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full px-3 py-2.5 pr-12 rounded-xl border border-border bg-card text-text focus:outline-none focus:ring-2 focus:ring-accent text-base"
+                  placeholder="8 caractères minimum"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={
+                    showPassword
+                      ? "Masquer le mot de passe"
+                      : "Afficher le mot de passe"
+                  }
+                  aria-pressed={showPassword}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-11 h-11 rounded-lg text-text-muted hover:text-text transition-colors"
+                >
+                  {showPassword ? (
+                    <EyeOff size={20} aria-hidden="true" />
+                  ) : (
+                    <Eye size={20} aria-hidden="true" />
+                  )}
+                </button>
+              </div>
+            </div>
 
             <label className="block">
               <span className="text-xs font-semibold text-text-muted">Âge</span>
@@ -546,9 +573,22 @@ function SignupQuickInner() {
   );
 }
 
+function SignupQuickFallback() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-bg">
+      <Loader2
+        size={28}
+        strokeWidth={1.8}
+        className="animate-spin text-accent"
+        aria-label="Chargement"
+      />
+    </main>
+  );
+}
+
 export default function SignupQuickPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<SignupQuickFallback />}>
       <SignupQuickInner />
     </Suspense>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,6 +117,32 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 .font-display { font-family: var(--font-display); }
 .tap-target { min-height: 44px; min-width: 44px; }
 
+/*
+ * Expanded tap area without resizing the visual.
+ *
+ * Use when the icon/glyph MUST stay smaller than 44px (e.g. compact
+ * undo glyph, dense action bars) but the touch target still needs to
+ * meet WCAG 2.5.5 / Apple HIG 44px. Renders an invisible ::before
+ * pseudo-element that grows the hit-area to ≥44×44 around the
+ * element's geometric center, without shifting layout or visuals.
+ *
+ * Required: the element must be `position: relative` (set here) and
+ * pointer-events should not be disabled on its parent overlay.
+ *
+ * Sweep WCAG 2.5.5 — 2026-04-27
+ */
+.tap-target-expand { position: relative; }
+.tap-target-expand::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+  transform: translate(-50%, -50%);
+  /* Invisible — the underlying element renders the visual */
+}
+
 /* === STORY RING === */
 .story-ring { padding:2px; background:linear-gradient(135deg,#8B5CF6,#00FF88); border-radius:9999px; }
 .story-ring-off { padding:2px; background:#EBEBEB; border-radius:9999px; }

--- a/src/components/app/FABMenu.tsx
+++ b/src/components/app/FABMenu.tsx
@@ -90,6 +90,10 @@ const positions = [
  *  - /safety, /safety/*  — FAB recouvrait le bouton/texte "Cercle de confiance"
  *                          (BUG-07, audit 2026-04-26). Page sensible (trust &
  *                          safety) — pas de quick-action utile ici.
+ *  - /events, /events/*  — FAB chevauchait le badge "Gratuit" sur les cartes
+ *                          d'evenements en bas du viewport (BUG-08 P1, audit
+ *                          2026-04-27). La page Soirees a deja ses propres CTAs
+ *                          (filtres + RSVP) — pas de quick-action utile ici.
  */
 function shouldHideFAB(pathname: string | null): boolean {
   if (!pathname) return false;
@@ -99,6 +103,7 @@ function shouldHideFAB(pathname: string | null): boolean {
   if (/^\/rooms\/[^/]+/.test(pathname)) return true;
   if (pathname.startsWith("/onboarding")) return true;
   if (pathname === "/safety" || pathname.startsWith("/safety/")) return true;
+  if (pathname === "/events" || pathname.startsWith("/events/")) return true;
   return false;
 }
 
@@ -203,7 +208,12 @@ export function FABMenu() {
                     <button
                       onClick={() => handleAction(action.href)}
                       role="menuitem"
-                      className="tap-target flex h-10 w-10 items-center justify-center rounded-full text-white shadow-lg transition-transform active:scale-90"
+                      // tap-target-expand keeps the 40px visual but renders a
+                      // 44px invisible hit area via ::before (WCAG 2.5.5 sweep
+                      // 2026-04-27). Previous `tap-target` forced the button to
+                      // visually grow to 44px which pushed the orbit layout off
+                      // the 440px desktop frame on narrow viewports.
+                      className="tap-target-expand flex h-10 w-10 items-center justify-center rounded-full text-white shadow-lg transition-transform active:scale-90"
                       style={{ backgroundColor: action.color }}
                       aria-label={action.label}
                     >

--- a/src/components/app/MatchCinematic.tsx
+++ b/src/components/app/MatchCinematic.tsx
@@ -14,7 +14,7 @@
  * Motion lib = motion/react (not framer-motion) — see constraints.
  */
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import type { Route } from "next";
 import Image from "next/image";
@@ -34,7 +34,14 @@ export interface MatchCinematicProps {
   sharedMode?: string | null;
   conversationId?: string | null;
   onDismiss: () => void;
+  /**
+   * Auto-dismiss timer in ms. Defaults to 8000 (Tinder/Bumble pattern).
+   * Set to 0 / null to disable auto-dismiss entirely.
+   */
+  autoDismissMs?: number | null;
 }
+
+const DEFAULT_AUTO_DISMISS_MS = 8000;
 
 // Confetti ring — 16 colored dots radiating outward. Uses the same palette
 // as the onboarding celebration screen for consistency.
@@ -48,7 +55,34 @@ export default function MatchCinematic({
   sharedMode,
   conversationId,
   onDismiss,
+  autoDismissMs = DEFAULT_AUTO_DISMISS_MS,
 }: MatchCinematicProps) {
+  // Auto-dismiss timer with pause-on-hover/tap support.
+  // Tracks whether the user is currently engaging with the card so we don't
+  // cut them off mid-read. Pausing clears the existing timer; unpausing restarts.
+  const [isPaused, setIsPaused] = useState(false);
+  const [hasFiredOnce, setHasFiredOnce] = useState(false);
+  const dismissedRef = useRef(false);
+
+  // Reset internal state every time the overlay reopens for a new match.
+  useEffect(() => {
+    if (open) {
+      setIsPaused(false);
+      setHasFiredOnce(false);
+      dismissedRef.current = false;
+    }
+  }, [open]);
+
+  // Wrap onDismiss so we can guard against double-fire (CTA click + timer race).
+  const safeDismiss = useCallback(() => {
+    if (dismissedRef.current) return;
+    dismissedRef.current = true;
+    onDismiss();
+  }, [onDismiss]);
+
+  // Pause/resume helpers wired to pointer + focus events on the card.
+  const pause = useCallback(() => setIsPaused(true), []);
+  const resume = useCallback(() => setIsPaused(false), []);
   // Resolve mode data — fallback gracefully if mode is legacy / null.
   const mode = useMemo(() => {
     if (sharedMode && isActiveMode(sharedMode)) return MODES[sharedMode as ModeKey];
@@ -86,11 +120,30 @@ export default function MatchCinematic({
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onDismiss();
+      if (e.key === "Escape") safeDismiss();
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, onDismiss]);
+  }, [open, safeDismiss]);
+
+  // Auto-dismiss timer — pausable. Re-creates the timer whenever isPaused flips
+  // back to false. Disabled when autoDismissMs is null/0. Only fires once per
+  // open cycle (hasFiredOnce gate) so we don't re-fire if the user briefly
+  // hovers then unhovers near the deadline.
+  useEffect(() => {
+    if (!open) return;
+    if (!autoDismissMs || autoDismissMs <= 0) return;
+    if (isPaused) return;
+    if (hasFiredOnce) return;
+    const t = window.setTimeout(() => {
+      setHasFiredOnce(true);
+      safeDismiss();
+    }, autoDismissMs);
+    return () => window.clearTimeout(t);
+  }, [open, autoDismissMs, isPaused, hasFiredOnce, safeDismiss]);
+
+  const showCountdown = Boolean(autoDismissMs && autoDismissMs > 0);
+  const countdownSeconds = autoDismissMs ? Math.round(autoDismissMs / 1000) : 0;
 
   const chatHref = conversationId
     ? `/chat/${conversationId}?starter=${encodeURIComponent(starter)}`
@@ -109,7 +162,7 @@ export default function MatchCinematic({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
         >
-          {/* Backdrop — dark, blurred */}
+          {/* Backdrop — dark, blurred. Tapping outside the card dismisses. */}
           <m.div
             className="absolute inset-0"
             style={{
@@ -121,7 +174,7 @@ export default function MatchCinematic({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={onDismiss}
+            onClick={safeDismiss}
           />
 
           {/* Ambient radial halo */}
@@ -172,10 +225,10 @@ export default function MatchCinematic({
             );
           })}
 
-          {/* Dismiss button */}
+          {/* Dismiss button (X top-right) */}
           <m.button
             type="button"
-            onClick={onDismiss}
+            onClick={safeDismiss}
             className="absolute top-5 right-5 z-10 w-9 h-9 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center text-white/70 hover:text-white tap-target"
             initial={{ opacity: 0 }}
             animate={{ opacity: 0.85 }}
@@ -186,8 +239,16 @@ export default function MatchCinematic({
             <X size={18} strokeWidth={2} aria-hidden="true" />
           </m.button>
 
-          {/* Content */}
-          <div className="relative z-[2] flex flex-col items-center text-center px-6 max-w-md">
+          {/* Content — hovering/tapping pauses the auto-dismiss timer so users
+              reading carefully don't get cut off mid-thought. */}
+          <div
+            className="relative z-[2] flex flex-col items-center text-center px-6 max-w-md"
+            onPointerEnter={pause}
+            onPointerLeave={resume}
+            onPointerDown={pause}
+            onFocus={pause}
+            onBlur={resume}
+          >
             {/* Top label */}
             <m.p
               className="text-[11px] font-bold uppercase tracking-[0.3em] mb-3"
@@ -277,13 +338,51 @@ export default function MatchCinematic({
             >
               <Link
                 href={chatHref as Route}
-                onClick={onDismiss}
+                onClick={() => {
+                  // Mark the cycle as fired so the auto-timer effect won't
+                  // re-fire onDismiss after navigation, then dismiss cleanly.
+                  setHasFiredOnce(true);
+                  safeDismiss();
+                }}
                 className="w-full inline-block gradient-bg text-white px-8 py-4 rounded-full text-[15px] font-bold shadow-glow tap-target"
               >
                 Dis bonjour
               </Link>
             </m.div>
           </div>
+
+          {/* Countdown indicator — bottom progress bar that drains over the
+              auto-dismiss window. Pauses (CSS animation-play-state) when the
+              user is hovering/tapping. Hidden if auto-dismiss is disabled. */}
+          {showCountdown && (
+            <div
+              className="absolute bottom-0 left-0 right-0 z-10 flex flex-col items-center gap-2 px-6 pb-4 pointer-events-none"
+              aria-hidden="true"
+            >
+              <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.25em] text-white/40">
+                {isPaused
+                  ? "En pause"
+                  : `Fermeture auto dans ${countdownSeconds}s`}
+              </div>
+              <div className="w-32 h-[2px] rounded-full bg-white/10 overflow-hidden">
+                <m.div
+                  key={`countdown-${open}-${isPaused}-${hasFiredOnce}`}
+                  className="h-full bg-white/50"
+                  initial={{ width: "100%" }}
+                  animate={{
+                    width: isPaused || hasFiredOnce ? "100%" : "0%",
+                  }}
+                  transition={{
+                    duration:
+                      isPaused || hasFiredOnce
+                        ? 0
+                        : (autoDismissMs ?? DEFAULT_AUTO_DISMISS_MS) / 1000,
+                    ease: "linear",
+                  }}
+                />
+              </div>
+            </div>
+          )}
         </m.div>
       )}
     </AnimatePresence>

--- a/src/components/messages/EmptyConversations.tsx
+++ b/src/components/messages/EmptyConversations.tsx
@@ -59,7 +59,7 @@ export function EmptyConversations() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...springs.heavy, delay: 0.1 }}
       >
-        Pas encore de conversation
+        Pas encore de conversations
       </m.h2>
 
       <m.p
@@ -68,8 +68,7 @@ export function EmptyConversations() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...springs.heavy, delay: 0.2 }}
       >
-        Le silence avant la magie. Découvre des profils et commence
-        ta première conversation CeSoir.
+        Quand tu matches, tes conversations apparaissent ici.
       </m.p>
 
       <m.div
@@ -86,7 +85,7 @@ export function EmptyConversations() {
               "0 10px 30px color-mix(in srgb, var(--color-accent) 28%, transparent)",
           }}
         >
-          Découvrir des profils
+          Commencer à explorer
           <span aria-hidden="true">{"\u2192"}</span>
         </Link>
       </m.div>

--- a/src/lib/referral.ts
+++ b/src/lib/referral.ts
@@ -1,111 +1,256 @@
-const REFERRAL_KEY = "cesoir_referral";
-const INVITES_KEY = "cesoir_invites";
+/**
+ * Referral helpers — DB-backed since Wave 16 Bet #2 (2026-04-27).
+ *
+ * Pre-Wave 16 the file was a localStorage-only stub from the original
+ * Wave 14 mock (kept around so unrelated badge logic compiled). Now that
+ * mig 025 has shipped the hybrid invite-reward model, every referral fact
+ * lives on `public.invite_codes` (created_by → who minted, used_by → who
+ * claimed). We read straight from the table — RLS already lets a user see
+ * the rows where `created_by = auth.uid()`.
+ *
+ * The +5 roses / +founder badge rewards are emitted atomically by the
+ * `claim_invite_code` RPC (mig 025). We don't have per-row reward columns
+ * on the table — instead we know the protocol constants and derive the
+ * stats from them. If migration 025 ever changes the per-claim payout,
+ * update `ROSES_PER_CLAIM` below.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import {
+  namespacedChannelName,
+  useRealtimeChannel,
+} from "@/lib/hooks/useSupabaseQuery";
+import { logger } from "@/lib/logger";
 
-export type ReferralTier = "none" | "bronze" | "argent" | "or" | "diamant";
+// ──────────────────────────────────────────────────────────────────────
+// Constants (mirrored from supabase/migrations/025_invite_rewards_hybrid.sql)
+// ──────────────────────────────────────────────────────────────────────
+
+/** Roses awarded to BOTH sides per successful claim. From mig 025 (v_roses_amount = 5). */
+export const ROSES_PER_CLAIM = 5;
+
+/** Achievement key minted by the RPC for the new user. */
+export const FOUNDER_ACHIEVEMENT_KEY = "founder";
+
+// ──────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────
+
+export interface ReferralCodeEntry {
+  /** The 8-char code itself. */
+  code: string;
+  /** auth.users.id of the friend who claimed this code, or null if unused. */
+  usedBy: string | null;
+  /** ISO timestamp of the claim, or null if unused. */
+  usedAt: string | null;
+  /** Roses the inviter earned for this claim. 0 if not yet used. Always +5 once claimed. */
+  rosesGranted: number;
+  /** Achievement key the new user received via this claim, or null if unused. */
+  badgeGranted: string | null;
+  /** ISO expiry timestamp (mig 021 default = +30 days). */
+  expiresAt: string;
+  /** ISO mint timestamp. */
+  createdAt: string;
+}
 
 export interface ReferralInfo {
+  /** Every code I've minted, newest first (active + used + expired). */
+  myCodes: ReferralCodeEntry[];
+  /** Number of distinct friends who claimed one of my codes. */
+  totalReferrals: number;
+  /** Sum of rose payouts attributed to me from referrals. */
+  totalRosesEarned: number;
+  /** Subset of `totalReferrals` who currently hold the 'founder' achievement. */
+  activeFounders: number;
+}
+
+interface InviteCodeRow {
   code: string;
-  tier: ReferralTier;
-  tierLabel: string;
-  tierIcon: string;
-  inviteCount: number;
-  nextTier: { name: string; remaining: number } | null;
+  used_by: string | null;
+  used_at: string | null;
+  expires_at: string;
+  created_at: string;
 }
 
-const TIERS: { min: number; key: ReferralTier; label: string; icon: string }[] = [
-  { min: 25, key: "diamant", label: "Diamant", icon: "\uD83D\uDC8E" },
-  { min: 10, key: "or", label: "Or", icon: "\uD83E\uDD47" },
-  { min: 5, key: "argent", label: "Argent", icon: "\uD83E\uDD48" },
-  { min: 1, key: "bronze", label: "Bronze", icon: "\uD83E\uDD49" },
-];
+// ──────────────────────────────────────────────────────────────────────
+// Core fetcher (server-callable, no React)
+// ──────────────────────────────────────────────────────────────────────
+
+const EMPTY_INFO: ReferralInfo = {
+  myCodes: [],
+  totalReferrals: 0,
+  totalRosesEarned: 0,
+  activeFounders: 0,
+};
 
 /**
- * Generate a unique referral code for a given user ID.
- * Deterministic: same userId always yields the same code.
+ * Fetch the user's referral stats straight from Supabase.
+ *
+ * Two queries:
+ *   1. `invite_codes WHERE created_by = $userId` — RLS-allowed for the owner.
+ *   2. `achievements WHERE achievement_key = 'founder' AND user_id IN (used_by[])`
+ *      — `achievements` has a public SELECT policy (mig 002), so this works
+ *      regardless of who the inviter is.
+ *
+ * Errors surface up — caller decides whether to swallow / toast / log.
  */
-export function generateReferralCode(userId: string): string {
-  // Simple hash-based code generation
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = ((hash << 5) - hash + userId.charCodeAt(i)) | 0;
-  }
-  const code = `CESOIR-${Math.abs(hash).toString(36).toUpperCase().slice(0, 6)}`;
-  return code;
-}
+export async function getReferralInfo(userId: string): Promise<ReferralInfo> {
+  if (!userId) return EMPTY_INFO;
 
-/**
- * Track a new invitation (stores in localStorage for demo).
- * In production, this would call an API.
- */
-export function trackInvite(referrerCode: string, inviteeId: string): void {
-  if (typeof window === "undefined") return;
-  const invites = getInvites(referrerCode);
-  if (!invites.includes(inviteeId)) {
-    invites.push(inviteeId);
-    localStorage.setItem(`${INVITES_KEY}_${referrerCode}`, JSON.stringify(invites));
-  }
-}
+  const { data: rows, error: codesErr } = await supabase
+    .from("invite_codes")
+    .select("code, used_by, used_at, expires_at, created_at")
+    .eq("created_by", userId)
+    .order("created_at", { ascending: false });
 
-function getInvites(code: string): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = localStorage.getItem(`${INVITES_KEY}_${code}`);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
+  if (codesErr) {
+    logger.error("referral_getReferralInfo_codes_failed", {
+      err: codesErr.message,
+    });
+    throw codesErr;
   }
-}
 
-function computeTier(count: number): { key: ReferralTier; label: string; icon: string } {
-  for (const tier of TIERS) {
-    if (count >= tier.min) return tier;
-  }
-  return { key: "none", label: "Aucun", icon: "" };
-}
+  const codes = (rows ?? []) as InviteCodeRow[];
+  const usedCodes = codes.filter((c) => c.used_by !== null);
+  const usedByIds = usedCodes
+    .map((c) => c.used_by)
+    .filter((v): v is string => v !== null);
 
-function computeNextTier(count: number): { name: string; remaining: number } | null {
-  // Find the next tier above current count
-  const sorted = [...TIERS].reverse(); // ascending by min
-  for (const tier of sorted) {
-    if (count < tier.min) {
-      return { name: tier.label, remaining: tier.min - count };
+  // Founder achievements — null payload when nobody claimed yet (skip the round-trip).
+  let founderUserIds = new Set<string>();
+  if (usedByIds.length > 0) {
+    const { data: achievements, error: achErr } = await supabase
+      .from("achievements")
+      .select("user_id")
+      .eq("achievement_key", FOUNDER_ACHIEVEMENT_KEY)
+      .in("user_id", usedByIds);
+
+    if (achErr) {
+      // Achievements are non-critical for the headline stats — log and move on
+      // so the page still renders the codes.
+      logger.warn("referral_getReferralInfo_achievements_failed", {
+        err: achErr.message,
+      });
+    } else {
+      founderUserIds = new Set(
+        (achievements ?? []).map((a: { user_id: string }) => a.user_id),
+      );
     }
   }
-  return null; // Already at max
-}
 
-/**
- * Get full referral info for a user.
- */
-export function getReferralInfo(userId: string): ReferralInfo {
-  const code = generateReferralCode(userId);
-  const invites = getInvites(code);
-  const count = invites.length;
-  const tier = computeTier(count);
-  const nextTier = computeNextTier(count);
+  const myCodes: ReferralCodeEntry[] = codes.map((c) => ({
+    code: c.code,
+    usedBy: c.used_by,
+    usedAt: c.used_at,
+    rosesGranted: c.used_by ? ROSES_PER_CLAIM : 0,
+    badgeGranted: c.used_by ? FOUNDER_ACHIEVEMENT_KEY : null,
+    expiresAt: c.expires_at,
+    createdAt: c.created_at,
+  }));
 
   return {
-    code,
-    tier: tier.key,
-    tierLabel: tier.label,
-    tierIcon: tier.icon,
-    inviteCount: count,
-    nextTier,
+    myCodes,
+    totalReferrals: usedCodes.length,
+    totalRosesEarned: usedCodes.length * ROSES_PER_CLAIM,
+    activeFounders: founderUserIds.size,
   };
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// Sharing helper (kept from the legacy stub — used by /invites/mine)
+// ──────────────────────────────────────────────────────────────────────
+
 /**
- * Save referral code to localStorage (so the user can see it later).
+ * Build the deep link a user should share for a given invite code.
+ *
+ * Server-safe: when `window` is undefined we fall back to the configured
+ * site URL so the link can also be embedded in transactional emails.
  */
-export function saveMyReferralCode(code: string): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(REFERRAL_KEY, code);
+export function buildInviteUrl(code: string): string {
+  const origin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_SITE_URL ?? "https://cesoir-app.vercel.app";
+  return `${origin}/signup-quick?invite=${encodeURIComponent(code)}`;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// React hook (with optional realtime subscription)
+// ──────────────────────────────────────────────────────────────────────
+
+export interface UseReferralInfoResult {
+  info: ReferralInfo;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
 }
 
 /**
- * Get the user's own saved referral code.
+ * React hook around `getReferralInfo` with a live Supabase realtime
+ * subscription on `invite_codes` filtered to rows the user owns.
+ *
+ * The subscription mirrors the canonical pattern from `useFeed` —
+ * per-user namespaced channel + `useRealtimeChannel` for guaranteed
+ * cleanup on unmount + auto-reconnect on `window.online`. We don't try
+ * to patch the local state by hand; instead any realtime UPDATE simply
+ * triggers a refetch of both queries (cheap — usually < 10 rows total).
  */
-export function getMyReferralCode(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(REFERRAL_KEY);
+export function useReferralInfo(
+  userId: string | null | undefined,
+): UseReferralInfoResult {
+  const [info, setInfo] = useState<ReferralInfo>(EMPTY_INFO);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    if (!userId) {
+      setInfo(EMPTY_INFO);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const next = await getReferralInfo(userId);
+      setInfo(next);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce]);
+
+  // Realtime: refresh whenever any of my invite_codes rows change. The
+  // RPC `claim_invite_code` UPDATEs (sets used_by + used_at) so the event
+  // we actually care about is UPDATE — but the filter is also valid for
+  // future INSERTs (e.g. minting more codes) and DELETEs (account purge).
+  useRealtimeChannel(
+    (client) =>
+      userId
+        ? client
+            .channel(namespacedChannelName("invite-codes-realtime", userId))
+            .on(
+              "postgres_changes",
+              {
+                event: "*",
+                schema: "public",
+                table: "invite_codes",
+                filter: `created_by=eq.${userId}`,
+              },
+              () => {
+                void fetchOnce();
+              },
+            )
+        : null,
+    [userId, fetchOnce],
+  );
+
+  return useMemo(
+    () => ({ info, loading, error, refetch: fetchOnce }),
+    [info, loading, error, fetchOnce],
+  );
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,104 @@
+/**
+ * Avatar URL helpers.
+ *
+ * Created alongside migration `028_avatar_bucket_security.sql` which
+ * flipped the `avatars` bucket from PUBLIC to PRIVATE. Any code path
+ * that previously stored a `https://<project>.supabase.co/storage/v1/object/public/avatars/...`
+ * URL on `profiles.avatar_url` will now 401 for unauthenticated
+ * fetches (e.g. the OG image route or any external scraper).
+ *
+ * Strategy:
+ *   - Inside an authenticated session, `getPublicUrl()` keeps working
+ *     because the storage gateway evaluates RLS — and our SELECT
+ *     policy allows any authenticated user to read any avatar.
+ *     So matched users (chat, /matches) and unmatched browse cards
+ *     keep rendering with a single GET.
+ *   - For unauthenticated SSR (OG image, public profile share card),
+ *     callers must use `createSignedUrl(path, 3600)` to mint a 1h
+ *     pre-signed URL.
+ *
+ * TODO (post-028 rollout):
+ *   - Audit `profiles.avatar_url` rows for the legacy `/object/public/`
+ *     prefix and either rewrite them on read or backfill to the
+ *     bucket-relative path so callers can always rebuild a URL of the
+ *     correct shape.
+ *   - Migrate `src/app/p/[id]/opengraph-image.tsx` from raw `<img>` to
+ *     a server-side fetch that calls `createSignedUrl` and inlines the
+ *     image bytes. Until then, OG previews fall back to ui-avatars.com.
+ *   - Decide whether to extend this helper to write (upload) — see
+ *     `src/components/app/PhotoUpload.tsx` lines 92-114 for the only
+ *     current writer.
+ */
+
+import { supabase } from "./supabase";
+
+/**
+ * Returns the canonical avatar path relative to the `avatars` bucket
+ * (e.g. `<userId>/<filename>.jpg`), or `null` if the input is falsy or
+ * doesn't look like a Supabase Storage URL.
+ *
+ * Accepts either:
+ *   - a bucket-relative path (`<uid>/avatar.jpg`) — returned as-is,
+ *   - a legacy public URL — extracts the segment after `/avatars/`,
+ *   - any other URL (e.g. ui-avatars.com placeholder) — returns null.
+ */
+export function avatarPathFromUrl(input: string | null | undefined): string | null {
+  if (!input) return null;
+  // Bucket-relative path — `uid/file.ext`. No protocol, no leading slash.
+  if (!input.includes("://") && !input.startsWith("/")) {
+    return input;
+  }
+  // Public or signed Supabase URL — both contain `/avatars/<rest>`.
+  const m = input.match(/\/avatars\/(.+?)(?:\?|$)/);
+  if (m?.[1]) return decodeURIComponent(m[1]);
+  return null;
+}
+
+/**
+ * Returns a URL the browser can render for an avatar.
+ *
+ * - `isMatched` flag is reserved for the next refactor: today's RLS
+ *   policy lets ANY authenticated user read any avatar, so the
+ *   matched/unmatched distinction doesn't change the SQL — but it
+ *   future-proofs the call sites for when we tighten the policy to
+ *   "matched OR own folder" only. Pass `true` for chat/matches,
+ *   `false` for browse swipe deck, undefined when you don't know.
+ * - When the storage `path` can't be derived (placeholder, external
+ *   URL), the function returns the input unchanged so existing
+ *   ui-avatars.com fallbacks keep working.
+ */
+export function getAvatarUrl(
+  pathOrUrl: string | null | undefined,
+  _isMatched?: boolean,
+): string | null {
+  if (!pathOrUrl) return null;
+  // External (ui-avatars.com, gravatar, etc.) — pass through.
+  if (/^https?:\/\//.test(pathOrUrl) && !pathOrUrl.includes("/avatars/")) {
+    return pathOrUrl;
+  }
+  const path = avatarPathFromUrl(pathOrUrl);
+  if (!path) return pathOrUrl;
+  const { data } = supabase.storage.from("avatars").getPublicUrl(path);
+  return data.publicUrl;
+}
+
+/**
+ * Mints a 1-hour signed URL for an avatar — required when the consumer
+ * runs OUTSIDE an authenticated session (SSR /p/[id], OG image route,
+ * email previews). Returns `null` on failure or for non-storage URLs.
+ *
+ * Default TTL is 3600s (1h). Pass a smaller value for ephemeral use
+ * cases (push notification thumbnails, share-card previews).
+ */
+export async function getAvatarSignedUrl(
+  pathOrUrl: string | null | undefined,
+  expiresInSeconds: number = 3600,
+): Promise<string | null> {
+  const path = avatarPathFromUrl(pathOrUrl);
+  if (!path) return null;
+  const { data, error } = await supabase.storage
+    .from("avatars")
+    .createSignedUrl(path, expiresInSeconds);
+  if (error || !data) return null;
+  return data.signedUrl;
+}

--- a/supabase/migrations/020_seed_events_montpellier.sql
+++ b/supabase/migrations/020_seed_events_montpellier.sql
@@ -171,7 +171,7 @@ INSERT INTO public.events (
   'grosse-radio-afterwork-2026-04-30',
   'Afterwork Electro-Jazz — La Grosse Radio',
   'Sortie bureau 19h-minuit. Cocktails signature, fusion jazz/electro, food truck ceviche à l''extérieur.',
-  'https://images.unsplash.com/photo-1546074177-ffdda98d214f?w=1200&q=80&auto=format',
+  'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=1200&q=80&auto=format',
   'La Grosse Radio', '8 rue du Plan d''Agde, 34000 Montpellier',
   ST_SetSRID(ST_MakePoint(3.8790, 43.6078), 4326)::geography,
   'montpellier',

--- a/supabase/migrations/027_fix_events_seed_photos.sql
+++ b/supabase/migrations/027_fix_events_seed_photos.sql
@@ -1,0 +1,21 @@
+-- ========================================================================
+-- Migration 027: Fix wrong cover photos on seeded events
+-- ========================================================================
+-- Production fix for Bug P1 (2026-04-27): "Afterwork Electro-Jazz —
+-- La Grosse Radio" was rendering with an unrelated stock photo of
+-- Scrabble tiles spelling "READ" (Unsplash ID photo-1546074177-ffdda98d214f).
+-- Migration 020 has been corrected at source for fresh installs, but
+-- existing databases need this UPDATE to propagate the fix without
+-- re-running the seed.
+--
+-- New cover: photo-1514525253161-7a46d19cd819 — jazz/nightclub stage,
+-- low-light, fits the electro-jazz afterwork vibe.
+--
+-- Idempotent: safe to re-run, only touches events whose cover_url is
+-- still the old (wrong) Scrabble URL.
+-- ========================================================================
+
+UPDATE public.events
+SET flyer_url = 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=1200&q=80&auto=format'
+WHERE title LIKE '%Afterwork Electro-Jazz%'
+  AND flyer_url LIKE '%photo-1546074177-ffdda98d214f%';

--- a/supabase/migrations/028_avatar_bucket_security.sql
+++ b/supabase/migrations/028_avatar_bucket_security.sql
@@ -1,0 +1,126 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- Migration 028 — Avatar Bucket Security (P0 audit follow-up)
+--
+-- Problem fixed:
+--   Migration 003 dropped the public-read policy "Avatar public read"
+--   on storage.objects, but did NOT flip the `avatars` bucket itself
+--   from public → private. Because Supabase Storage serves any object
+--   in a `public = true` bucket via the public URL endpoint
+--   (`/storage/v1/object/public/avatars/...`) WITHOUT consulting RLS,
+--   anyone with the URL — including users whose accounts have been
+--   deleted by `/api/account/delete` — could still read the file.
+--
+--   That's an RGPD violation: an account-delete leaves the avatar
+--   binaries publicly fetchable until manual cleanup of the bucket
+--   itself. Even after the row in storage.objects is removed by
+--   `userClient.storage.from("avatars").remove(paths)`, the file
+--   itself is gone — but anyone who scraped the URL while the user
+--   existed still has a working public link if the bucket re-creates
+--   the object (e.g. via upsert in a different code path).
+--
+-- Fix strategy:
+--   1. Flip the bucket to private — `/object/public/...` will now 401.
+--   2. Replace the missing SELECT policy with an authenticated-only
+--      read policy (any logged-in user can read any avatar). Browse
+--      cards and chat thumbnails still work, just with a signed URL
+--      (or a `getPublicUrl` that now requires auth context — same
+--      thing under the hood once bucket is private: the gateway
+--      checks RLS).
+--   3. Tighten INSERT/UPDATE/DELETE to user's own folder only.
+--
+-- Client-side impact:
+--   Public URLs of the form
+--     https://<project>.supabase.co/storage/v1/object/public/avatars/<uid>/<file>
+--   stop working for unauthenticated requests. After this migration,
+--   clients MUST either:
+--     • use `supabase.storage.from("avatars").getPublicUrl(path)` from
+--       within an authenticated session — the gateway will now return
+--       the file as long as the user is logged in (RLS check passes),
+--     • or call `createSignedUrl(path, 3600)` for embeds that need to
+--       work outside the user's session (e.g. shared profile cards
+--       fetched by an unauthenticated SSR render of /p/[id]).
+--
+--   For matched users (chat list, /matches grid), an authenticated
+--   `getPublicUrl` is sufficient — the user is logged in.
+--   For UNMATCHED browse cards (/browse swipe deck), same thing —
+--   user is logged in. The "public-URL leak to anon" risk is what we
+--   are closing here.
+--   For the OG image route at /p/[id]/opengraph-image.tsx — that one
+--   runs server-side without a user session and previously relied on
+--   the public URL to embed the avatar in the og:image. After this
+--   migration that fetch will 401 and the OG image will fall back to
+--   the ui-avatars.com placeholder. Acceptable for now (OG previews
+--   are a vanity feature, not a security boundary). A signed URL
+--   served by an SSR API route would be the correct long-term fix.
+-- ═══════════════════════════════════════════════════════════════════
+
+-- ─── 1. Flip the bucket to private ──────────────────────────────────
+UPDATE storage.buckets SET public = false WHERE id = 'avatars';
+
+-- ─── 2. Restore SELECT policy (authenticated-only) ──────────────────
+-- Drop any leftover variants from earlier migrations or manual edits
+-- in the Supabase dashboard so we end up with exactly one policy.
+DROP POLICY IF EXISTS "Avatars: anyone can read" ON storage.objects;
+DROP POLICY IF EXISTS "Avatars: public read" ON storage.objects;
+DROP POLICY IF EXISTS "Avatar public read" ON storage.objects;
+DROP POLICY IF EXISTS "Avatars: authenticated read" ON storage.objects;
+
+CREATE POLICY "Avatars: authenticated read" ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND auth.role() = 'authenticated'
+  );
+
+-- ─── 3. Tighten write policies to {userId}/* folder ─────────────────
+-- INSERT — user can only upload into their own folder.
+DROP POLICY IF EXISTS "Avatars: own folder write" ON storage.objects;
+DROP POLICY IF EXISTS "Avatars: own folder insert" ON storage.objects;
+
+CREATE POLICY "Avatars: own folder insert" ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- UPDATE — user can only modify objects in their own folder
+-- (covers `upsert: true` from PhotoUpload.tsx and any future rename).
+DROP POLICY IF EXISTS "Avatars: own folder update" ON storage.objects;
+
+CREATE POLICY "Avatars: own folder update" ON storage.objects
+  FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- DELETE — user can only delete objects in their own folder.
+-- Keeps migration 003's "Avatar delete own" policy, but drops + re-adds
+-- under the consistent naming so future audits find one policy per op.
+DROP POLICY IF EXISTS "Avatar delete own" ON storage.objects;
+DROP POLICY IF EXISTS "Avatars: own folder delete" ON storage.objects;
+
+CREATE POLICY "Avatars: own folder delete" ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- ─── 4. Documentation comment on the bucket itself ──────────────────
+-- Stored as a Postgres comment so anyone exploring the schema via psql
+-- or the dashboard sees the rationale without diffing migrations.
+COMMENT ON TABLE storage.objects IS
+  'Avatars bucket is PRIVATE since migration 028 (RGPD). '
+  'Public URLs (/storage/v1/object/public/avatars/...) return 401. '
+  'Clients must call getPublicUrl() inside an authenticated session, '
+  'or createSignedUrl(path, 3600) for unauthenticated SSR embeds.';


### PR DESCRIPTION
## Summary

Round 4 of the parallel audit. **10 specialist agents in parallel**, each scoped to a single non-overlapping deliverable. 22 files changed + 3 new migrations + 3 Wave 16 readiness specs.

## P1 visual / UX (shipped)

| # | Bug | Fix |
|---|---|---|
| 1 | /events Scrabble READ photo on Afterwork Electro-Jazz | New Unsplash ID + migration 027 idempotent UPDATE |
| 2 | /events FAB overlaps "Gratuit" badge | Added /events to shouldHideFAB() |
| 3 | /events no empty state | New EventsEmptyState + clear-filters CTA |
| 4 | /events no loading skeleton | 3 placeholder cards animate-pulse |
| 5 | /map subtitle clip | min-w-0 max-w-[160px] truncate + title attr |
| 6 | /squad "Rejoindre" invisible disabled | opacity 40→60 + min-w + textShadow |
| 7 | /chat icebreakers truncate | max-w 200→240 + line-clamp-2 |
| 8 | /chat empty state copy | Aligned to spec |
| 9 | login/register/signup-quick no password show/hide | Eye/EyeOff toggle, 3 forms |
| 10 | Match cinematic 4s too short + no controls | 8s, pause-on-interact, countdown bar, Escape, backdrop, CTA guard |
| 11 | 7 Suspense fallback={null} = blank flash | PageLoader + SkeletonList + Loader2 spinners |
| 12 | Touch targets <44px (4 sites) | New .tap-target-expand utility (no visual change) |

## Wave 16 prep

**Bet #2 (DB-backed referral) — SHIPPED in this PR**
- localStorage stub `getReferralInfo()` → async DB query
- Returns `{ myCodes, totalReferrals, totalRosesEarned, activeFounders }`
- New `useReferralInfo()` hook with realtime sub on `invite_codes` changes
- /invites/mine page rewired with stats card + relative time labels

**Bet #1 (Stripe activation) — readiness audit ONLY**
Score: **6/10**. Recommendation: NO-GO on flag-flip alone. Top 3 blockers documented in `audit/round4/WAVE-16-STRIPE-READINESS.md`. Estimated activation: 2.5-3 h test mode.

**Bet #4 (Push notifications) — spec ONLY**
14 h estimated. Push_subscriptions table missing despite being referenced in account-delete. Hook + SW handler 100% built. Spec: `audit/round4/WAVE-16-PUSH-NOTIFS.md`.

**Bet #5 (Gamification frontend) — spec ONLY**
10 h estimated. `useGamification.showLevelUp` state machine wired but rendered by NOTHING. Spec: `audit/round4/WAVE-16-GAMIFICATION-FRONTEND.md`.

## P0 follow-up: avatar bucket security

New migration `028_avatar_bucket_security.sql`: avatars bucket → private; restore SELECT policy for authenticated; tighten INSERT/UPDATE/DELETE to {userId}/* folder. **NOT applied** — requires explicit `supabase db push` per user decision. New helper `src/lib/storage.ts` with signed-URL strategy. Risk assessment in agent report.

## Verification

- ✓ `npx tsc --noEmit` → 0 errors (all 10 agents reported clean)
- ✓ Local dev server live at http://localhost:3000
- ✓ Chrome opened side-by-side: local (round 4 fixes) + prod (PR #38 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)