### PR TITLE
fix(safety): unicode escape leaked as literal text

### DIFF
--- a/src/app/(app)/safety/page.tsx
+++ b/src/app/(app)/safety/page.tsx
@@ -587,7 +587,7 @@ export default function SafetyPage() {
           className="block text-center text-[13px] font-semibold mb-20 tap-target py-2"
           style={{ color: "var(--color-accent)" }}
         >
-          {"\u2190"} Retour \u00e0 l&apos;exploration
+          {"←"} Retour à l&apos;exploration
         </Link>
       </main>
     </div>


### PR DESCRIPTION
Bug found in production audit: '/safety' bottom link displayed 'Retour à l'exploration' instead of 'Retour à l'exploration'. The escape sequence was in JSX text, not a JS string literal — so Next rendered it as literal characters.