### PR TITLE
fix(swipe): stuck card + residual accents

### DIFF
--- a/src/app/(app)/progress/page.tsx
+++ b/src/app/(app)/progress/page.tsx
@@ -20,7 +20,7 @@ type Tab = "achievements" | "challenges" | "leaderboard" | "trust" | "reviews";
 
 const TABS: { key: Tab; label: string; emoji: string }[] = [
   { key: "achievements", label: "Badges", emoji: "\uD83C\uDFC6" },
-  { key: "challenges", label: "Defis", emoji: "\u26A1" },
+  { key: "challenges", label: "Défis", emoji: "\u26A1" },
   { key: "leaderboard", label: "Classement", emoji: "\uD83D\uDC51" },
   { key: "trust", label: "Confiance", emoji: "\u2728" },
   { key: "reviews", label: "Reviews", emoji: "\uD83D\uDCAC" },
@@ -46,7 +46,7 @@ function AchievementsTab() {
       <EmptyState
         emoji="🏆"
         title="Aucun badge pour le moment"
-        subtitle="Demarre une conversation, valide ton profil, sors — debloque des badges."
+        subtitle="Démarre une conversation, valide ton profil, sors — débloque des badges."
       />
     );
   }
@@ -55,7 +55,7 @@ function AchievementsTab() {
     <div className="px-5 py-4">
       <div className="mb-4 flex items-center justify-between text-[12px] text-text-muted">
         <span>
-          <strong className="text-text">{totalEarned}</strong>/{all.length} badges debloquees
+          <strong className="text-text">{totalEarned}</strong>/{all.length} badges débloqués
         </span>
         <span>{earned.reduce((sum, bp) => sum + bp.badge.xp, 0)} XP</span>
       </div>

--- a/src/app/invite/[code]/page.tsx
+++ b/src/app/invite/[code]/page.tsx
@@ -265,7 +265,7 @@ export default function InvitePage() {
               >
                 {[
                   { icon: "🌙", text: "4 modes de rencontre" },
-                  { icon: "📍", text: "Trouve des gens pres de toi, ce soir" },
+                  { icon: "📍", text: "Trouve des gens près de toi, ce soir" },
                   { icon: "💯", text: "100% gratuit, zero paywall" },
                 ].map((item, i) => (
                   <m.div

--- a/src/components/landing/PhoneVideo.tsx
+++ b/src/components/landing/PhoneVideo.tsx
@@ -167,7 +167,7 @@ function SceneFeed() {
   const profiles = [
     { label: "Nouveau profil", mode: "Solo Diner", dist: "tout pres", color: "#8B5CF6" },
     { label: "Quelqu'un comme toi", mode: "Night Owl", dist: "ce soir", color: "#6366F1" },
-    { label: "Match possible", mode: "Langues", dist: "pres de toi", color: "#06B6D4" },
+    { label: "Match possible", mode: "Langues", dist: "près de toi", color: "#06B6D4" },
     { label: "Dispo maintenant", mode: "Gaming", dist: "juste a cote", color: "#EC4899" },
   ];
 

--- a/src/lib/motion-design.ts
+++ b/src/lib/motion-design.ts
@@ -81,10 +81,17 @@ export const feedVariants = {
  */
 export const browseVariants = {
   card: {
-    initial: { scale: 0.8, rotateY: -10, opacity: 0 },
+    // 2026-04-27 fix (user-reported "swipe figé"): explicitly reset x and
+    // rotateZ on initial. Without these, AnimatePresence in sync mode
+    // could leave the new card at x:-400 / rotateZ:-15 inherited from
+    // the previous card's swipeLeft exit, so the next profile rendered
+    // off-screen and the deck looked frozen on the background-stack image.
+    initial: { scale: 0.8, rotateY: -10, opacity: 0, x: 0, rotateZ: 0 },
     center: {
       scale: 1,
       rotateY: 0,
+      rotateZ: 0,
+      x: 0,
       opacity: 1,
       transition: springs.rubber,
     },

--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -483,7 +483,7 @@ export function getSmartNotifications(prefs: UserPreferences): SmartNotification
     notifications.push({
       id: "notif-nearby",
       type: "nearby",
-      title: `${randomCount} personnes en mode ${modeName} pres de toi`,
+      title: `${randomCount} personnes en mode ${modeName} près de toi`,
       body: `C'est ton heure preferee pour sortir — il y a du monde ce soir !`,
       icon: "\uD83D\uDCCD",
       priority: 8,

--- a/src/lib/useGeolocation.ts
+++ b/src/lib/useGeolocation.ts
@@ -115,7 +115,7 @@ export function useGeolocation(): UseGeolocationResult {
       setLoading(false);
       switch (err.code) {
         case err.PERMISSION_DENIED:
-          setError("Active la geolocalisation pour voir les gens pres de toi");
+          setError("Active la géolocalisation pour voir les gens près de toi");
           break;
         case err.POSITION_UNAVAILABLE:
           setError("Position indisponible");

--- a/src/lib/useLiveNotifications.ts
+++ b/src/lib/useLiveNotifications.ts
@@ -92,7 +92,7 @@ export function useLiveNotifications(): {
       next.push({
         id: "online",
         icon: "\uD83D\uDD14",
-        message: `${onlineCount} ${onlineCount === 1 ? "personne dispo" : "personnes dispos"} pres de toi ce soir`,
+        message: `${onlineCount} ${onlineCount === 1 ? "personne dispo" : "personnes dispos"} près de toi ce soir`,
       });
     }
 

--- a/src/lib/useSwipe.ts
+++ b/src/lib/useSwipe.ts
@@ -22,15 +22,23 @@ export function useSwipe(onAction: (action: "like" | "pass") => void): SwipeResu
   const nextScale = useTransform(x, [-200, 0, 200], [1, 0.94, 1]);
 
   const go = useCallback((action: "like" | "pass") => {
-    animate(x, action === "like" ? 500 : -500, {
+    // 2026-04-27 fix (user-reported "swipe figé"): use animation's
+    // onComplete instead of an arbitrary setTimeout(300). With the spring
+    // physics and stiffness=300/damping=30, the actual animation can run
+    // 350-500ms — so the previous setTimeout fired BEFORE the spring
+    // settled, then x.set(0) raced with the still-running animation.
+    // Result: the next card sometimes inherited a non-zero x and rendered
+    // off-screen.
+    const controls = animate(x, action === "like" ? 500 : -500, {
       type: "spring",
       stiffness: 300,
       damping: 30,
+      onComplete: () => {
+        onAction(action);
+        x.set(0);
+      },
     });
-    setTimeout(() => {
-      onAction(action);
-      x.set(0);
-    }, 300);
+    return controls;
   }, [onAction, x]);
 
   const onDragEnd = useCallback(


### PR DESCRIPTION
User reported card stuck after swipe (screenshot showed card off-screen with empty visible slot). Root cause: AnimatePresence sync mode + missing x:0 reset on card.initial + setTimeout race in useSwipe. Fixed both. Plus 5 'pres de toi' and 3 /progress accent fixes from prod audit.