### PR TITLE
fix(build): /api/waitlist prerender crash blocking all PRs

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -10,14 +10,30 @@ import { logger } from "@/lib/logger";
  *
  * Cached at the edge for 60s to keep landing rendering snappy; the view
  * is cheap (single aggregate) but we still don't need second-precision.
+ *
+ * Next.js 16 note: `revalidate` route segment is removed when Cache
+ * Components are enabled. The HTTP Cache-Control header below is what
+ * actually drives the 60s edge cache. Build-time prerender is avoided
+ * by lazy-init of the Supabase client + missing-env early return —
+ * Vercel build context doesn't expose the public env vars during static
+ * generation of API routes.
  */
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
-
-export const revalidate = 60;
-
 export async function GET() {
+  const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+  // Guard: if env vars are missing (Vercel build static-generation phase
+  // or local dev without .env), serve a graceful fallback instead of
+  // crashing the build. createClient() throws "supabaseUrl is required"
+  // on empty string — that's what was breaking the production build.
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return NextResponse.json(
+      { signedUp: 0, error: "env_missing" },
+      { status: 200 },
+    );
+  }
+
   const db = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
   const { data, error } = await db


### PR DESCRIPTION
## Summary
- Lazy-init Supabase client in /api/waitlist GET — was crashing the build with \`supabaseUrl is required\` because Next.js 16 prerenders API routes at build time but Vercel doesn't expose NEXT_PUBLIC_* env vars during static generation.
- Early-return graceful fallback (\`{ signedUp: 0, error: \"env_missing\" }\`) when env missing.
- Removed dead \`export const revalidate = 60\` (Next.js 16 removes this segment when Cache Components enabled). Edge cache still driven by existing Cache-Control header.

## Why this matters
This single bug was failing the Vercel preview deploy on **all 7 open PRs** (#49 #50 #51 #52 #53 #54 #55) — none of them touched /api/waitlist but all inherit the failing build from master.

Merging this first unblocks the entire Wave 1 + Wave 2 review/merge pipeline.

## Test plan
- [ ] Vercel preview deploy goes green
- [ ] /api/waitlist returns \`{signedUp: N}\` in prod (env vars present)
- [ ] Build succeeds without \`supabaseUrl is required\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)